### PR TITLE
feat(ansible): add playbook and role for installing docker_engine

### DIFF
--- a/ansible/playbooks/docker_engine.yml
+++ b/ansible/playbooks/docker_engine.yml
@@ -1,0 +1,5 @@
+---
+- hosts: proxmox_vm
+  become: yes
+  roles:
+    - docker_engine

--- a/ansible/roles/docker_engine/tasks/Debian.yml
+++ b/ansible/roles/docker_engine/tasks/Debian.yml
@@ -1,0 +1,34 @@
+---
+- name: prereq install a list of packages for docker engine
+  apt:
+    update_cache: yes
+    state: latest
+    pkg:
+      - curl
+      - ca-certificates
+      - gnupg
+      - lsb-release
+
+- name: create keyring directory
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+
+- name: download and add docker official gpg to keyring
+  shell: curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+- name: generate sources.list for docker
+  template:
+    src: docker.list.j2
+    dest: /etc/apt/sources.list.d/docker.list
+  become: true
+
+- name: install a list of packages for docker engine
+  apt:
+    update_cache: yes
+    state: latest
+    pkg:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - docker-compose-plugin

--- a/ansible/roles/docker_engine/tasks/main.yml
+++ b/ansible/roles/docker_engine/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- include_tasks: Debian.yml
+  when: ansible_os_family == "Debian"

--- a/ansible/roles/docker_engine/templates/docker.list.j2
+++ b/ansible/roles/docker_engine/templates/docker.list.j2
@@ -1,0 +1,1 @@
+deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian   {{ ansible_distribution_release }} stable


### PR DESCRIPTION
Deployed to test-server and confirm that it's working

```
duely@test-server:~$ sudo docker run hello-world
Unable to find image 'hello-world:latest' locally
latest: Pulling from library/hello-world
2db29710123e: Pull complete 
Digest: sha256:aa0cc8055b82dc2509bed2e19b275c8f463506616377219d9642221ab53cf9fe
Status: Downloaded newer image for hello-world:latest

Hello from Docker!
This message shows that your installation appears to be working correctly.
```