### PR TITLE
Create cloud-init packer template for proxmox

### DIFF
--- a/ansible/group_vars/all/operators.yml
+++ b/ansible/group_vars/all/operators.yml
@@ -4,3 +4,7 @@ operators:
     comment: duely
     ssh_keys:
       - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCp3zgT/IZBUDgTlGm83q1P0UHCsK9yGKqnrf7h1QtluHo2SRD2JWafOK9wSjxl/GQxpNyL23p19GW8CcrEXMnPq48kLSMeUmJGKUWDZkGUK2UF58kNKk8+kJ8W+RthFBgASbJLZADQs7ih820u+9JB2yZiTQ8t4O0JW1vO5ArRs96JPqumpH64fUc+zp5eLBIj0+Qmck78gqaZ8ZEtu568ZJOHeoMEPRMyattTP7+DjMRlkKaOy9kaQomyYdt/G4xnYlC89t+xO/lLrqMno64+ihdfjy7UeLwse+mvW4V0+Qx6KybCUWyvpo6rAspZmEoG3fxGvh51pnZeJRibygYwcfPphvRbQGNrzWEPuWWtQLb+bGRa58jqFUTf+9a5OQTr2EfpDRRXdc2zS3Io3A7+OmaRnfQ1pYw7xjqeJuYoLX958Wn5r3r7927z4a/ZV+j5XgdAL6Z8iB9vt3jL9YIklcKcIV0ZnlxqkXkyUCPDZhcwn1qrgu4tLokH1+5FghoBjz0XTu2RGRWDoJ9FQaBtdc+1ZTuyqd82jkW+QTuU1f5mBliA0vTcMZMGaySe/ivtUzaECzmEvWUzu0dA71y/dszMCBYg5ZV0k99G/AGOgH0jwg3NSq6auqxlok2soeaPbipSWtcbUX5QkULO9CpHGOVnpNng9Lg/2aaEMPy26w=='
+  - name: ansible
+    comment: ansible
+    ssh_keys:
+      - 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHBFGXcVb+nOAYTOtUT2rcSinKXIirlj/1IMmxxCOtdf'

--- a/packer/README.md
+++ b/packer/README.md
@@ -9,7 +9,7 @@ brew upgrade hashicorp/tap/packer
 
 ## Create user, role, and token for Packer
 ```
-pveum role add Packer -privs "Datastore.AllocateSpace Sys.Modify VM.Config.Disk VM.Config.CPU VM.Config.Memory VM.Config.Options VM.Allocate VM.Audit VM.Console VM.Config.CDROM VM.Config.Network VM.PowerMgmt VM.Config.HWType VM.Monitor"
+pveum role add Packer -privs "Datastore.AllocateSpace Sys.Modify VM.Config.Disk VM.Config.CPU VM.Config.Memory VM.Config.Options VM.Allocate VM.Audit VM.Console VM.Config.CDROM VM.Config.Network VM.PowerMgmt VM.Config.HWType VM.Monitor VM.Config.Cloudinit"
 pveum user add packer@pve -comment "Packer API user"
 pveum acl modify / -user packer@pve -role Packer
 pveum user token add packer@pve packer1

--- a/packer/debian-bullseye-proxmox.pkr.hcl
+++ b/packer/debian-bullseye-proxmox.pkr.hcl
@@ -11,6 +11,8 @@ source "proxmox" "debian_bullseye" {
     "vga=788 noprompt quiet --<enter>"
   ]
   boot_wait    = "10s"
+  cloud_init   = true
+  cloud_init_storage_pool = "vmstore"
   disks {
     disk_size         = "32G"
     storage_pool      = "vmstore"
@@ -35,16 +37,39 @@ source "proxmox" "debian_bullseye" {
   token                = "${var.proxmox_token}"
   unmount_iso          = true
   username             = "${var.proxmox_user}"
-  vm_id                = 200
+  vm_id                = 201
 }
 
 build {
   sources = ["source.proxmox.debian_bullseye"]
 
+  provisioner "file" {
+      destination = "/tmp/requirements.txt"
+      source = "../requirements.txt"
+  }
+
   provisioner "shell" {
-    inline = [
-      "mkdir -p /home/ansible/.ssh",
-      "echo ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHBFGXcVb+nOAYTOtUT2rcSinKXIirlj/1IMmxxCOtdf ansible >> /home/ansible/.ssh/authorized_keys",
+    execute_command = "{{.Vars}} sudo -S -E bash '{{.Path}}'"
+    scripts = [
+      "scripts/ansible.sh"
+    ]
+  }
+
+  provisioner "ansible-local" {
+    command = "ANSIBLE_FORCE_COLOR=1 PYTHONUNBUFFERED=1 ansible-playbook"
+    extra_arguments= [
+      "-e 'ansible_python_interpreter=/usr/bin/python3'"
+    ]
+    inventory_groups = ["all"]
+    playbook_dir = "../ansible"
+    playbook_file = "../ansible/playbooks/operators.yml"
+  }
+
+  provisioner "shell" {
+    execute_command = "{{.Vars}} sudo -S -E bash '{{.Path}}'"
+    expect_disconnect = "true"
+    scripts = [
+      "scripts/cleanup.sh"
     ]
   }
 }

--- a/packer/debian-bullseye-proxmox.pkr.hcl
+++ b/packer/debian-bullseye-proxmox.pkr.hcl
@@ -37,7 +37,7 @@ source "proxmox" "debian_bullseye" {
   token                = "${var.proxmox_token}"
   unmount_iso          = true
   username             = "${var.proxmox_user}"
-  vm_id                = 201
+  vm_id                = 200
 }
 
 build {

--- a/packer/scripts/ansible.sh
+++ b/packer/scripts/ansible.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -eux
+# Install ansible, required for the ansible-local packer provisioner
+
+apt-get -q update
+apt-get -q upgrade -y
+apt-get -q install cmake python3 python3-dev python-setuptools build-essential libssl-dev libffi-dev lsof facter python3-pip wget -y
+
+pip3 install -qUr /tmp/requirements.txt --no-cache-dir
+
+# Newer jinja2 breaks cloud-init, need to overrite with existing packages
+pip3 uninstall -y jinja2 markupsafe
+apt-get install -y --reinstall python3-jinja2 python3-markupsafe

--- a/packer/scripts/cleanup.sh
+++ b/packer/scripts/cleanup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eux
+
+shred -u /etc/ssh/*_key /etc/ssh/*_key.pub
+ssh-keygen -A
+
+rm -rf /etc/udev/rules.d/70-persistent-net.rules
+touch /etc/udev/rules.d/70-persistent-net.rules
+rm -f /lib/udev/rules.d/75-persistent-net-generator.rules
+rm -rf /dev/.udev /var/lib/dhcp3/* /var/lib/dhcp/*
+
+rm -rf *.iso
+rm -rf /var/tmp/* /tmp/*
+rm -rf /var/lib/cloud/instances/*
+rm -f /var/lib/cloud/instance
+
+for user in root; do rm -rf /home/$user/{.viminfo,.bash_history,.ssh} ; done
+
+find /var/log -type f -exec /bin/rm -f {} \;
+
+touch /var/log/lastlog
+history -c
+history -w

--- a/packer/scripts/debian-fix-persistent-net-rules.sh
+++ b/packer/scripts/debian-fix-persistent-net-rules.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+rm -rf /etc/udev/rules.d/70-persistent-net.rules
+touch /etc/udev/rules.d/70-persistent-net.rules

--- a/packer/scripts/repos-bullseye.sh
+++ b/packer/scripts/repos-bullseye.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -eux
+
+apt-get -q install apt-transport-https -y
+rm -rf /etc/apt/sources.list.d/*
+
+# makes apt work
+cat << EOF > /etc/apt/apt.conf.d/99translations
+Acquire::Languages "none";
+EOF
+
+apt-get -q clean
+apt-get -q update -y
+DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
+apt-get -q autoremove -y

--- a/packer/scripts/sshd.sh
+++ b/packer/scripts/sshd.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -eux
+
+tee -a /etc/ssh/sshd_config <<EOF
+
+UseDNS no
+EOF


### PR DESCRIPTION
* Refactor packer by including scripts and adding ansible-local provisioners
* Have packer run the ansible playbook for `operators`, so SSH keys can be available (post setup will require to run the entire base.yml playbook, so it can update MOTD and hostname)
* Had to update the permission for `Packer` role, so Proxmox can add the cloud-init drive