### PR TITLE
feat: init bitwarden-secretstore

### DIFF
--- a/helm/bitwarden-secretstore/README.md
+++ b/helm/bitwarden-secretstore/README.md
@@ -1,0 +1,42 @@
+# Bitwarden Secret Store for k3s
+
+## Installation
+```
+helm repo add bitwarden https://charts.bitwarden.com/
+helm repo update
+helm show values bitwarden/sm-operator --devel > values.yaml
+helm upgrade sm-operator bitwarden/sm-operator -i --debug -n bitwarden --create-namespace --values values.yaml --devel
+```
+
+
+## Create Bitwarden secrets
+1. From Bitwarden Secrets Manager, you will need to create a "machine account"
+2. Run the below command with the "machine account" token
+```
+kubectl create secret generic bw-auth-token -n bitwarden --from-literal=token="<TOKEN_HERE>"
+```
+
+## Deploy BitwardenSecret
+Need to explcitly expose the secret that should be synced from Bitwarden to Kubernetes Secret
+
+```
+cat <<EOF | kubectl apply -n bitwarden -f -
+apiVersion: k8s.bitwarden.com/v1
+kind: BitwardenSecret
+metadata:
+  name: bitwarden
+spec:
+  organizationId: "67133d60-9c46-4fe4-8e26-b1e001633fd7"
+  secretName: bitwarden
+  onlyMappedSecrets: true # default is true
+  map:
+    - bwSecretId: 36cc39d5-ecbd-4459-9f9b-b3f3004d53a9
+      secretKeyName: db-001_password
+  authToken:
+    secretName: bw-auth-token
+    secretKey: token
+EOF
+```
+
+## Source
+https://bitwarden.com/help/secrets-manager-kubernetes-operator/

--- a/helm/bitwarden-secretstore/values.yaml
+++ b/helm/bitwarden-secretstore/values.yaml
@@ -1,0 +1,80 @@
+settings:
+  # How often the secrets synchronize in seconds.  Minimum value is 180.
+  bwSecretsManagerRefreshInterval: 300
+  # Define Cloud-region to supply the server-URL if using a Bitwarden Cloud vault.  Set to either 'US' or 'EU'
+  # If self-hosted, leave blank and set bwApiUrlOverride instead
+  # https://bitwarden.com/help/server-geographies/
+  cloudRegion: US
+  # Set only if self-hosted.  These are the URLs for the Bitwarden API and Identity services
+  bwApiUrlOverride:
+  bwIdentityUrlOverride:
+  # This is the internal Kubernetes DNS zone.  You will likely not need to change this
+  # unless you have specifically changed the internal DNS name.
+  kubernetesClusterDomain: cluster.local
+  # The number of operator pod replicas to run.  When in doubt, leave at 1
+  replicas: 1
+
+# Optional: Custom labels to be applied to all resources created by the operator
+# This can be used to identify the Bitwarden Secrets Manager project or for any other labeling needs
+# Example:
+#   commonLabels:
+#     custom-label: custom-label-value
+commonLabels: {}
+
+# Settings specific to the pod containers
+containers:
+  manager:
+    image:
+      # NOTE:  This should be updated before the final PR
+      repository: ghcr.io/bitwarden/sm-operator
+      # Will default to the Chart's AppVersion, but you can override here.
+      tag:
+    # The pod resource requirements.  You can adjust these up and down for your environment
+    resources:
+      limits:
+        cpu: 500m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 64Mi
+    terminationGracePeriodSeconds: 10
+
+  # Provide annotations for the service account
+  serviceAccount:
+    annotations: {}
+  # Set to false to work on older Kubernetes versions (< 1.19) or on vendors versions
+  # which do NOT support this field by default (i.e. OpenShift < 4.11 ).
+  # This setting is recommended for most common cases that do not require escalating privileges
+  # to make containers restrictive.
+  # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
+  enableSeccompProfileRuntimeDefault: true
+  # Optional value if you have privatized the image and need to pull with credentials
+  imagePullSecrets:
+  # Optionally place deployment on specifc nodes
+  nodeSelector: {}
+  # Optionally add taint tolerations
+  tolerations: []
+
+# Service endpoint configuration for the metrics service.
+metricsService:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  type: ClusterIP
+
+livenessProbe:
+  initialDelaySeconds: 15
+  periodSeconds: 20
+  timeoutSeconds: 1
+  successThreshold: 1
+  failureThreshold: 3
+
+readinessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 1
+  successThreshold: 1
+  failureThreshold: 3
+


### PR DESCRIPTION
Installed and verified that it's working

```
% kubectl get ns
NAME              STATUS   AGE
...
bitwarden         Active   30m

% kubectl -n bitwarden get po
NAME                                              READY   STATUS    RESTARTS   AGE
sm-operator-controller-manager-765f66b8bb-g2rpv   1/1     Running   0          30m

% kubectl -n bitwarden get secret bitwarden        
NAME        TYPE     DATA   AGE
bitwarden   Opaque   1      14m

% kubectl -n bitwarden describe secret bitwarden
Name:         bitwarden
Namespace:    bitwarden
Labels:       k8s.bitwarden.com/bw-secret=8de3f277-4e1f-46e6-8327-0d909a7db701
Annotations:  k8s.bitwarden.com/custom-map:
                [
                  {
                    "bwSecretId": "36cc39d5-ecbd-4459-9f9b-b3f3004d53a9",
                    "secretKeyName": "db-001_password"
                  }
                ]
              k8s.bitwarden.com/sync-time: 2026-02-16T05:14:29.855496338Z

Type:  Opaque

Data
====
db-001_password:  8 bytes
```