### PR TITLE
feat(terraform): add PostgreSQL LXC module

### DIFF
--- a/terraform/modules/proxmox-lxc/main.tf
+++ b/terraform/modules/proxmox-lxc/main.tf
@@ -1,0 +1,47 @@
+resource "proxmox_lxc" "this" {
+  name        = var.vm_name
+  target_node = var.target_node
+  ostemplate  = var.ostemplate
+  description = var.vm_desc
+
+  # Resources
+  cores  = var.cores
+  memory = var.memory
+  swap   = var.swap
+
+  # Root filesystem
+  rootfs {
+    size = var.rootfs_size
+    pool = var.rootfs_storage
+  }
+
+  # Data mount for PostgreSQL data
+  mount {
+    key    = "mp0"
+    slot   = 0
+    size   = var.data_mount_size
+    pool   = var.data_mount_storage
+    path   = var.data_mount_path
+    backup = false
+  }
+
+  # Network configuration
+  network {
+    id     = 0
+    name   = "eth0"
+    bridge = var.network_bridge
+    ip     = var.network_ip
+    gw     = var.network_gateway
+  }
+
+  # OS type
+  os_type {
+    distribution = "debian"
+    version      = "12"
+  }
+
+  # Features
+  features {
+    nesting = false
+  }
+}

--- a/terraform/modules/proxmox-lxc/output.tf
+++ b/terraform/modules/proxmox-lxc/output.tf
@@ -1,0 +1,19 @@
+output "vmid" {
+  description = "The container ID assigned by Proxmox"
+  value       = proxmox_lxc.this.vmid
+}
+
+output "container_name" {
+  description = "The name of the container"
+  value       = proxmox_lxc.this.name
+}
+
+output "container_ip" {
+  description = "The IP address of the container"
+  value       = proxmox_lxc.this.network.0.ip
+}
+
+output "node" {
+  description = "The Proxmox node on which the container was created"
+  value       = var.target_node
+}

--- a/terraform/modules/proxmox-lxc/providers.tf
+++ b/terraform/modules/proxmox-lxc/providers.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    proxmox = {
+      source  = "Telmate/proxmox"
+      version = "3.0.2-rc07"
+    }
+  }
+}
+
+provider "proxmox" {
+  pm_api_url      = "https://${var.pm_api_url}:8006/api2/json"
+  pm_tls_insecure = true
+}

--- a/terraform/modules/proxmox-lxc/variables.tf
+++ b/terraform/modules/proxmox-lxc/variables.tf
@@ -1,0 +1,101 @@
+variable "cores" {
+  type        = number
+  description = "Number of CPU cores"
+  default     = 1
+}
+
+variable "memory" {
+  type        = number
+  description = "Memory in MB"
+  default     = 512
+}
+
+variable "swap" {
+  type        = number
+  description = "Swap in MB"
+  default     = 256
+}
+
+variable "rootfs_size" {
+  type        = string
+  description = "Root filesystem size"
+  default     = "2G"
+}
+
+variable "rootfs_storage" {
+  type        = string
+  description = "Storage pool for root filesystem"
+  default     = "local"
+}
+
+variable "data_mount_size" {
+  type        = string
+  description = "Data mount size"
+  default     = "5G"
+}
+
+variable "data_mount_storage" {
+  type        = string
+  description = "Storage pool for data mount"
+  default     = "vmstore"
+}
+
+variable "data_mount_path" {
+  type        = string
+  description = "Mount path for data within container"
+  default     = "/var/lib/postgresql/data"
+}
+
+variable "pm_api_url" {
+  type        = string
+  description = "Proxmox API URL"
+  default     = "192.168.1.20"
+}
+
+variable "target_node" {
+  type        = string
+  description = "Proxmox node name"
+  default     = "proxmox-001"
+}
+
+variable "vm_name" {
+  type        = string
+  description = "Container name"
+  default     = ""
+}
+
+variable "vm_desc" {
+  type        = string
+  description = "Container description"
+  default     = ""
+}
+
+variable "ostemplate" {
+  type        = string
+  description = "LXC OS template"
+  default     = "vzdump:local:vztmpl/debian-12-standard_12.7-1_amd64.tar.zst"
+}
+
+variable "storage_pool" {
+  type        = string
+  description = "Default storage pool"
+  default     = "local"
+}
+
+variable "network_bridge" {
+  type        = string
+  description = "Network bridge"
+  default     = "vmbr0"
+}
+
+variable "network_ip" {
+  type        = string
+  description = "DHCP or static IP (dhcp for auto)"
+  default     = "dhcp"
+}
+
+variable "network_gateway" {
+  type        = string
+  description = "Network gateway (required for static IP)"
+  default     = ""
+}

--- a/terraform/proxmox/proxmox-001/postgres-lxc/.terraform.lock.hcl
+++ b/terraform/proxmox/proxmox-001/postgres-lxc/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/telmate/proxmox" {
+  version     = "3.0.2-rc07"
+  constraints = "3.0.2-rc07"
+  hashes = [
+    "h1:0UpRJ8PFsu9lhD3p2KUdUNVsDPbjZLPR46wYRpt1dxc=",
+    "zh:2ee860cd0a368b3eaa53f4a9ea46f16dab8a97929e813ea6ef55183f8112c2ca",
+    "zh:415965fd915bae2040d7f79e45f64d6e3ae61149c10114efeac1b34687d7296c",
+    "zh:6584b2055df0e32062561c615e3b6b2c291ca8c959440adda09ef3ec1e1436bd",
+    "zh:65dcfad71928e0a8dd9befc22524ed686be5020b0024dc5cca5184c7420eeb6b",
+    "zh:7253dc29bd265d33f2791ac4f779c5413f16720bb717de8e6c5fcb2c858648ea",
+    "zh:7ec8993da10a47606670f9f67cfd10719a7580641d11c7aa761121c4a2bd66fb",
+    "zh:999a3f7a9dcf517967fc537e6ec930a8172203642fb01b8e1f78f908373db210",
+    "zh:a50e6df7280eb6584a5fd2456e3f5b6df13b2ec8a7fa4605511e438e1863be42",
+    "zh:b25b329a1e42681c509d027fee0365414f0cc5062b65690cfc3386aab16132ae",
+    "zh:c028877fdb438ece48f7bc02b65bbae9ca7b7befbd260e519ccab6c0cbb39f26",
+    "zh:cf0eaa3ea9fcc6d62793637947f1b8d7c885b6ad74695ab47e134e4ff132190f",
+    "zh:d5ade3fae031cc629b7c512a7b60e46570f4c41665e88a595d7efd943dde5ab2",
+    "zh:f388c15ad1ecfc09e7361e3b98bae9b627a3a85f7b908c9f40650969c949901c",
+    "zh:f415cc6f735a3971faae6ac24034afdb9ee83373ef8de19a9631c187d5adc7db",
+  ]
+}

--- a/terraform/proxmox/proxmox-001/postgres-lxc/main.tf
+++ b/terraform/proxmox/proxmox-001/postgres-lxc/main.tf
@@ -1,0 +1,32 @@
+module "postgres_lxc" {
+  source = "../../../modules/proxmox-lxc"
+
+  # Container identification
+  vm_name = "postgres-001"
+  vm_desc = "PostgreSQL container with 5GB vmstore for data"
+
+  # Proxmox connection
+  pm_api_url  = var.pm_api_url
+  target_node = var.target_node
+
+  # LXC template
+  ostemplate = "vzdump:local:vztmpl/debian-12-standard_12.7-1_amd64.tar.zst"
+
+  # Minimal resources for PostgreSQL
+  cores  = 1
+  memory = 512
+  swap   = 256
+
+  # Root filesystem (small, just for OS)
+  rootfs_size     = "2G"
+  rootfs_storage  = "local"
+
+  # Data mount for PostgreSQL data (5GB on vmstore)
+  data_mount_size    = "5G"
+  data_mount_storage = "vmstore"
+  data_mount_path    = "/var/lib/postgresql/data"
+
+  # Network
+  network_bridge = "vmbr0"
+  network_ip     = "dhcp"
+}

--- a/terraform/proxmox/proxmox-001/postgres-lxc/output.tf
+++ b/terraform/proxmox/proxmox-001/postgres-lxc/output.tf
@@ -1,0 +1,19 @@
+output "postgres_vmid" {
+  description = "PostgreSQL container ID"
+  value       = module.postgres_lxc.vmid
+}
+
+output "postgres_container_name" {
+  description = "PostgreSQL container name"
+  value       = module.postgres_lxc.container_name
+}
+
+output "postgres_container_ip" {
+  description = "PostgreSQL container IP address"
+  value       = module.postgres_lxc.container_ip
+}
+
+output "postgres_node" {
+  description = "Proxmox node where PostgreSQL container is running"
+  value       = module.postgres_lxc.node
+}

--- a/terraform/proxmox/proxmox-001/postgres-lxc/providers.tf
+++ b/terraform/proxmox/proxmox-001/postgres-lxc/providers.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    proxmox = {
+      source  = "Telmate/proxmox"
+      version = "3.0.2-rc07"
+    }
+  }
+}
+
+provider "proxmox" {
+  pm_api_url      = "https://${var.pm_api_url}:8006/api2/json"
+  pm_tls_insecure = true
+}

--- a/terraform/proxmox/proxmox-001/postgres-lxc/variables.tf
+++ b/terraform/proxmox/proxmox-001/postgres-lxc/variables.tf
@@ -1,0 +1,11 @@
+variable "pm_api_url" {
+  type        = string
+  description = "Proxmox API URL"
+  default     = "192.168.1.20"
+}
+
+variable "target_node" {
+  type        = string
+  description = "Proxmox node name"
+  default     = "proxmox-001"
+}


### PR DESCRIPTION
## Summary
- Add reusable Terraform module for Proxmox LXC containers with configurable mount points
- Configure minimal resources (1 CPU core, 512MB RAM) suitable for PostgreSQL
- Add 5GB vmstore mount for PostgreSQL data directory at `/var/lib/postgresql/data`
- Create postgres-lxc instance on proxmox-001 using the new module

## Test plan
- [ ] Run `terraform init` and `terraform plan` in postgres-lxc directory
- [ ] Verify plan looks correct (1 LXC container with mount)
- [ ] Run `terraform apply` to create the container
- [ ] Verify container in Proxmox UI
- [ ] Run Ansible playbook for PostgreSQL setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)