### PR TITLE
feat(flux): add Flux CD bootstrap for k3s cluster

### DIFF
--- a/ansible/playbooks/flux.yml
+++ b/ansible/playbooks/flux.yml
@@ -1,0 +1,6 @@
+---
+- name: Bootstrap Flux CD
+  hosts: k3s
+  become: true
+  roles:
+    - flux

--- a/ansible/roles/flux/defaults/main.yml
+++ b/ansible/roles/flux/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# GitHub configuration
+flux_github_owner: duelyyung
+flux_github_repository: homelab
+flux_github_branch: main
+flux_github_path: clusters/k3s

--- a/ansible/roles/flux/tasks/main.yml
+++ b/ansible/roles/flux/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+- name: Install Flux CLI
+  ansible.builtin.get_url:
+    url: https://github.com/fluxcd/flux2/releases/latest/download/flux_darwin_amd64
+    dest: /usr/local/bin/flux
+    mode: '0755'
+  when: ansible_os_family == "Darwin"
+
+- name: Install Flux CLI on Linux
+  ansible.builtin.get_url:
+    url: https://github.com/fluxcd/flux2/releases/latest/download/flux_linux_amd64
+    dest: /usr/local/bin/flux
+    mode: '0755'
+  when: ansible_os_family == "Linux"
+
+- name: Create GitHub token secret for Flux
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: flux-github-token
+        namespace: flux-system
+      type: Opaque
+      stringData:
+        token: "{{ flux_github_token }}"
+
+- name: Bootstrap Flux on the cluster
+  ansible.builtin.command:
+    cmd: |
+      flux bootstrap git
+      --owner={{ flux_github_owner }}
+      --repository={{ flux_github_repository }}
+      --branch={{ flux_github_branch }}
+      --path={{ flux_github_path }}
+      --token-auth
+  environment:
+    FLUX_GITHUB_TOKEN: "{{ flux_github_token }}"
+  register: flux_bootstrap
+  failed_when: false
+
+- name: Verify Flux installation
+  ansible.builtin.command:
+    cmd: flux get all -A
+  register: flux_status
+  changed_when: false
+  failed_when: false

--- a/clusters/k3s/gotk-sync.yaml
+++ b/clusters/k3s/gotk-sync.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/gitrepository.source.toolkit.fluxcd.io/gitrepository.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: homelab
+  namespace: flux-system
+spec:
+  interval: 1m
+  ref:
+    branch: main
+  url: https://github.com/duelyyung/homelab
+  secretRef:
+    name: flux-github-token
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/kustomize.toolkit.fluxcd.io/kustomization.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: clusters/k3s
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: homelab
+  targetNamespace: default

--- a/clusters/k3s/helm-releases.yaml
+++ b/clusters/k3s/helm-releases.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/helm.toolkit.fluxcd.io/helmrelease.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bitwarden-secretstore
+  namespace: default
+spec:
+  chart:
+    spec:
+      chart: ./helm/bitwarden-secretstore
+      sourceRef:
+        kind: GitRepository
+        name: homelab
+        namespace: flux-system
+  interval: 1h
+  targetNamespace: default
+  install:
+    createNamespace: true
+  upgrade:
+    crds: Skip
+  values:
+    # Override values here if needed
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/kustomize.toolkit.fluxcd.io/kustomization.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: pgdumpall
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./helm/pgdumpall
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: homelab
+    namespace: flux-system
+  targetNamespace: default

--- a/clusters/k3s/kustomization.yaml
+++ b/clusters/k3s/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - gotk-sync.yaml
+  - helm-releases.yaml


### PR DESCRIPTION
## Summary
- Add Ansible role to install Flux CLI and bootstrap the k3s cluster
- Create GitRepository and Kustomization resources for cluster sync
- Add HelmRelease for bitwarden-secretstore chart
- Add Kustomization for pgdumpall CronJob

## Test plan
- [ ] Run `ansible-playbook playbooks/flux.yml` on k3s host
- [ ] Verify Flux is installed with `flux get all -A`
- [ ] Check Helm releases with `flux get helmreleases`
- [ ] Confirm workloads are running with `kubectl get all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)