### PR TITLE
feat(flux): add FluxCD bootstrap for k3s via minikube

### DIFF
--- a/flux/README.md
+++ b/flux/README.md
@@ -1,0 +1,91 @@
+# FluxCD Bootstrap for k3s
+
+This directory contains the FluxCD bootstrap configuration for managing an external k3s cluster using minikube as the bootstrap cluster.
+
+## Architecture
+
+- **Bootstrap Cluster**: minikube runs locally and hosts the Flux controllers
+- **Managed Cluster**: External k3s cluster (on Proxmox) managed via Flux's multi-cluster setup
+- **Git Source**: This repository contains the cluster manifests
+
+## Prerequisites
+
+- minikube installed and running
+- kubectl configured
+- flux CLI installed
+
+## Setup
+
+### 1. Start minikube
+
+```bash
+minikube start --cpus 2 --memory 4096
+```
+
+### 2. Install Flux controllers
+
+```bash
+flux install \
+  --namespace=flux-system \
+  --network-policy=false \
+  --components=source-controller,kustomize-controller,helm-controller,notification-controller
+```
+
+### 3. Add your Git repository
+
+```bash
+flux create source git flux-system \
+  --url=https://github.com/duelyyung/homelab \
+  --branch=main \
+  --interval=30s \
+  --namespace=flux-system
+```
+
+### 4. Create k3s cluster secret
+
+```bash
+# Get your k3s kubeconfig
+kubectl create secret generic k3s-cluster \
+  --from-file=value=kubeconfig-k3s.yaml \
+  --namespace=flux-system
+```
+
+### 5. Apply the cluster configuration
+
+```bash
+kubectl apply -f clusters/
+```
+
+## Directory Structure
+
+```
+flux/
+├── README.md
+├── clusters/
+│   └── k3s/
+│       ├── kustomization.yaml
+│       └── flux-sync.yaml
+├── bootstrap/
+│   └── flux-install.yaml
+└── scripts/
+    └── bootstrap.sh
+```
+
+## Verification
+
+```bash
+# Check flux status
+flux get sources git
+flux get kustomizations
+
+# Check reconciliation
+flux reconcile kustomization flux-system
+```
+
+## Troubleshooting
+
+```bash
+# View flux logs
+kubectl logs -n flux-system deploy/source-controller
+kubectl logs -n flux-system deploy/kustomize-controller
+```

--- a/flux/bootstrap/flux-install.yaml
+++ b/flux/bootstrap/flux-install.yaml
@@ -1,0 +1,25 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: flux-system
+  namespace: flux-system
+spec:
+  interval: 30s
+  ref:
+    branch: main
+  url: https://github.com/duelyyung/homelab
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: flux-system
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: ./flux/bootstrap
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  validation:
+    client: false

--- a/flux/clusters/k3s/flux-sync.yaml
+++ b/flux/clusters/k3s/flux-sync.yaml
@@ -1,0 +1,28 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: k3s-manifests
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  ref:
+    branch: main
+  url: https://github.com/duelyyung/homelab
+  timeout: 60s
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: k3s-manifests
+  namespace: flux-system
+spec:
+  interval: 5m0s
+  path: ./k3s
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: k3s-manifests
+  timeout: 5m
+  wait: true
+  retryInterval: 1m
+  suspend: false

--- a/flux/clusters/k3s/kustomization.yaml
+++ b/flux/clusters/k3s/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - flux-sync.yaml

--- a/flux/scripts/bootstrap.sh
+++ b/flux/scripts/bootstrap.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -euo pipefail
+
+# FluxCD Bootstrap Script for k3s via minikube
+# This script bootstraps FluxCD in minikube to manage an external k3s cluster
+
+NAMESPACE="${FLUX_NAMESPACE:-flux-system}"
+K3S_SECRET_NAME="${K3S_SECRET_NAME:-k3s-cluster}"
+K3S_KUBECONFIG="${K3S_KUBECONFIG:-$HOME/.kube/config-k3s}"
+
+echo "=== FluxCD Bootstrap for k3s ==="
+echo ""
+
+# Check prerequisites
+command -v flux >/dev/null 2>&1 || { echo "flux CLI not found. Please install flux."; exit 1; }
+command -v kubectl >/dev/null 2>&1 || { echo "kubectl not found. Please install kubectl."; exit 1; }
+command -v minikube >/dev/null 2>&1 || { echo "minikube not found. Please install minikube."; exit 1; }
+
+# 1. Start minikube if not running
+echo "[1/6] Checking minikube status..."
+if ! minikube status >/dev/null 2>&1; then
+    echo "Starting minikube..."
+    minikube start --cpus 2 --memory 4096
+else
+    echo "Minikube is already running"
+fi
+
+# 2. Create namespace
+echo "[2/6] Creating $NAMESPACE namespace..."
+kubectl create namespace $NAMESPACE --dry-run=client -o yaml | kubectl apply -f -
+
+# 3. Install Flux controllers
+echo "[3/6] Installing Flux controllers..."
+if ! flux check --namespace=$NAMESPACE 2>/dev/null | grep -q "installed"; then
+    flux install \
+        --namespace=$NAMESPACE \
+        --network-policy=false \
+        --components=source-controller,kustomize-controller,helm-controller,notification-controller \
+        --export | kubectl apply -f -
+    echo "Flux installed successfully"
+else
+    echo "Flux is already installed"
+fi
+
+# 4. Create GitRepository source
+echo "[4/6] Creating GitRepository source..."
+cat <<EOF | kubectl apply -f -
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: flux-system
+  namespace: $NAMESPACE
+spec:
+  interval: 30s
+  ref:
+    branch: main
+  url: https://github.com/duelyyung/homelab
+EOF
+
+# 5. Create K3s cluster secret (if kubeconfig exists)
+echo "[5/6] Setting up k3s cluster secret..."
+if [ -f "$K3S_KUBECONFIG" ]; then
+    kubectl create secret generic $K3S_SECRET_NAME \
+        --from-file=value=$K3S_KUBECONFIG \
+        --namespace=$NAMESPACE \
+        --dry-run=client -o yaml | kubectl apply -f -
+    echo "k3s cluster secret created"
+else
+    echo "k3s kubeconfig not found at $K3S_KUBECONFIG, skipping secret creation"
+fi
+
+# 6. Apply cluster configurations
+echo "[6/6] Applying cluster configurations..."
+kubectl apply -f "$(dirname "$0")/../clusters/"
+
+echo ""
+echo "=== Bootstrap complete ==="
+echo ""
+echo "Verify with:"
+echo "  flux get sources git"
+echo "  flux get kustomizations"
+echo "  kubectl get pods -n $NAMESPACE"


### PR DESCRIPTION
## Summary

This PR sets up FluxCD to manage an external k3s cluster using minikube as the bootstrap cluster. This enables GitOps workflows for the k3s cluster running on Proxmox.

## Changes

- **flux/README.md** - Setup documentation and usage guide
- **flux/bootstrap/flux-install.yaml** - Flux installation manifests
- **flux/clusters/k3s/flux-sync.yaml** - k3s cluster sync configuration
- **flux/clusters/k3s/kustomization.yaml** - Kustomize config for k3s
- **flux/scripts/bootstrap.sh** - Automated bootstrap script

## Architecture

- **Bootstrap Cluster**: minikube runs locally and hosts the Flux controllers
- **Managed Cluster**: External k3s cluster (on Proxmox) managed via Flux multi-cluster setup
- **Git Source**: This repository contains the cluster manifests

## Usage

```bash
# Start minikube
minikube start --cpus 2 --memory 4096

# Run bootstrap
./flux/scripts/bootstrap.sh
```

## Verification

```bash
flux get sources git
flux get kustomizations
kubectl get pods -n flux-system
```