### PR TITLE
feat(garage-s3): Add Garage S3 LXC deployment with Terraform + Ansible

### DIFF
--- a/ansible/playbooks/garage-s3.yml
+++ b/ansible/playbooks/garage-s3.yml
@@ -1,0 +1,6 @@
+---
+- name: Deploy Garage S3
+  hosts: garage-s3
+  become: yes
+  roles:
+    - garage_s3

--- a/ansible/roles/garage_s3/handlers/main.yml
+++ b/ansible/roles/garage_s3/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: reload-systemd
+  systemd:
+    daemon_reload: yes
+
+- name: restart garage
+  systemd:
+    name: garage
+    state: restarted
+    daemon_reload: yes

--- a/ansible/roles/garage_s3/tasks/main.yml
+++ b/ansible/roles/garage_s3/tasks/main.yml
@@ -1,0 +1,52 @@
+---
+- name: install prerequisites
+  apt:
+    update_cache: yes
+    pkg:
+      - curl
+      - ca-certificates
+      - gnupg
+
+- name: create garage data directory
+  file:
+    path: /mnt/garage-data
+    state: directory
+    mode: '0755'
+
+- name: download garage binary
+  get_url:
+    url: https://github.com/1F365/garage/releases/download/v2.1.0/garage_2.1.0_amd64.deb
+    dest: /tmp/garage_2.1.0_amd64.deb
+    mode: '0644'
+
+- name: install garage package
+  apt:
+    deb: /tmp/garage_2.1.0_amd64.deb
+    state: present
+
+- name: create garage config directory
+  file:
+    path: /etc/garage
+    state: directory
+    mode: '0755'
+
+- name: deploy garage configuration
+  template:
+    src: garage.toml.j2
+    dest: /etc/garage/garage.toml
+    mode: '0644'
+  notify: restart garage
+
+- name: create systemd service for garage
+  template:
+    src: garage.service.j2
+    dest: /etc/systemd/system/garage.service
+    mode: '0644'
+  notify: reload-systemd
+
+- name: enable and start garage service
+  systemd:
+    name: garage
+    enabled: yes
+    state: started
+    daemon_reload: yes

--- a/ansible/roles/garage_s3/templates/garage.service.j2
+++ b/ansible/roles/garage_s3/templates/garage.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description=Garage S3 Server
+After=network.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/local/bin/garage server --config /etc/garage/garage.toml
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/garage_s3/templates/garage.toml.j2
+++ b/ansible/roles/garage_s3/templates/garage.toml.j2
@@ -1,0 +1,21 @@
+[metadata]
+name = "garage-s3"
+description = "Garage S3 cluster"
+
+[api]
+api_host = "0.0.0.0:3900"
+rpc_host = "127.0.0.1:3901"
+region = "homelab"
+zone = "default"
+block_size = 4194304
+
+[replication]
+replica_factor = 1
+
+[storage]
+db_dir = "/mnt/garage-data/db"
+data_dir = "/mnt/garage-data/data"
+
+[s3_api]
+s3_api = "enabled"
+api_port = 3900

--- a/terraform/modules/proxmox-lxc/main.tf
+++ b/terraform/modules/proxmox-lxc/main.tf
@@ -1,0 +1,51 @@
+resource "proxmox_virtual_environment_container" "this" {
+  name          = var.container_name
+  description   = "Garage S3 container"
+  node_name     = var.target_node
+  start_on_boot = var.start_on_boot
+
+  cpu {
+    cores = var.cores
+  }
+
+  memory {
+    dedicated = var.memory
+  }
+
+  disk {
+    datastore_id = var.rootfs_storage
+    size         = 16
+  }
+
+  network_interface {
+    name   = "eth0"
+    bridge = var.network_bridge
+  }
+
+  dynamic "mount_point" {
+    for_each = var.nfs_server != null ? [1] : []
+    content {
+      volume = var.nfs_storage != null ? var.nfs_storage : "${var.nfs_server}:${var.nfs_path}"
+      size   = null
+      path   = var.nfs_mount_point
+    }
+  }
+
+  features {
+    mount = ["nfs"]
+  }
+
+  initialization {
+    hostname = var.container_name
+  }
+
+  operating_system {
+    template_file_id = var.os_template
+  }
+
+  lifecycle {
+    ignore_changes = [
+      network_interface[0].mac_address,
+    ]
+  }
+}

--- a/terraform/modules/proxmox-lxc/output.tf
+++ b/terraform/modules/proxmox-lxc/output.tf
@@ -1,0 +1,14 @@
+output "container_id" {
+  description = "The resource ID of the LXC container"
+  value       = proxmox_virtual_environment_container.this.id
+}
+
+output "container_name" {
+  description = "The name of the LXC container"
+  value       = proxmox_virtual_environment_container.this.container_name
+}
+
+output "container_node" {
+  description = "The Proxmox node where the container is running"
+  value       = proxmox_virtual_environment_container.this.node_name
+}

--- a/terraform/modules/proxmox-lxc/providers.tf
+++ b/terraform/modules/proxmox-lxc/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    proxmox = {
+      source  = "bpg/proxmox"
+      version = ">= 0.94.0"
+    }
+  }
+}

--- a/terraform/modules/proxmox-lxc/variables.tf
+++ b/terraform/modules/proxmox-lxc/variables.tf
@@ -1,0 +1,76 @@
+variable "container_name" {
+  type        = string
+  description = "The name of the LXC container"
+}
+
+variable "target_node" {
+  type        = string
+  description = "The Proxmox node on which to create the container"
+  default     = "proxmox-001"
+}
+
+variable "os_template" {
+  type        = string
+  description = "The OS template to use for the container"
+  default     = "local:vztmpl/debian-12-standard.tar.gz"
+}
+
+variable "cores" {
+  type        = number
+  description = "Number of CPU cores"
+  default     = 2
+}
+
+variable "memory" {
+  type        = number
+  description = "Amount of memory in MB"
+  default     = 2048
+}
+
+variable "rootfs_size" {
+  type        = number
+  description = "Size of the rootfs disk in GB"
+  default     = 16
+}
+
+variable "rootfs_storage" {
+  type        = string
+  description = "Storage pool for rootfs"
+  default     = "vmstore"
+}
+
+variable "network_bridge" {
+  type        = string
+  description = "Network bridge to use"
+  default     = "vmbr0"
+}
+
+variable "nfs_server" {
+  type        = string
+  description = "NFS server address"
+  default     = null
+}
+
+variable "nfs_path" {
+  type        = string
+  description = "NFS export path"
+  default     = null
+}
+
+variable "nfs_mount_point" {
+  type        = string
+  description = "Mount point path inside container"
+  default     = "/mnt/nfs"
+}
+
+variable "nfs_storage" {
+  type        = string
+  description = "Proxmox storage name for NFS mount"
+  default     = null
+}
+
+variable "start_on_boot" {
+  type        = bool
+  description = "Start container on boot"
+  default     = true
+}

--- a/terraform/proxmox/proxmox-001/garage-s3/.terraform.lock.hcl
+++ b/terraform/proxmox/proxmox-001/garage-s3/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/bpg/proxmox" {
+  version     = "0.98.1"
+  constraints = ">= 0.94.0"
+  hashes = [
+    "h1:oegYetLP9VqFSnRfHeUQnm6v58dH/VT4ivJSXg4RLnI=",
+    "zh:165705d0a0db92ccc5b1d23b0033cc87011f1151f4f178ad9df61473c3ca30b5",
+    "zh:3ecab62be80d89cf8f019ab23809254f854eb5a443682a1a22a52e0d80b1273f",
+    "zh:48b520a3f5b8cccca66e0dc7b1e264e01d2f35ef8a9bbfc6b02964cd7235914b",
+    "zh:7fa7e166b924b5192ff963f47a56772c7b34f0004d825d830c3122eab970534f",
+    "zh:804bdf5353d3a3ad9d06e6faada1b8600af8ecfd1e5b23280a81e62b0cb7037d",
+    "zh:87ebe8b56a895870ebc0d353fba5ebbb4615401dc3f53a2e157f158cb9025d2d",
+    "zh:9b0c8e02c036152bcb2f54c354da4647d10d016396e5ca2b70084a8bd5546970",
+    "zh:a0039465282dc75ac9c53750b61ba4038d56bed545cb39df669b6216bdff82da",
+    "zh:bbc2c187c8283b6a5f44cbd65f4b6e5d534a3be1eeb1a7c8caaaa6f1a7e48e76",
+    "zh:d04aed773582e95c8d7610833e85b204fe8c01c09c94e7128914c8e22b9218c7",
+    "zh:d7a1433a7d6f1b158f499a93d3fb1825eec73eac4c61b00a39f2f5e95ae0965a",
+    "zh:df46cb59fa1ddda335934720ad22d8205bb8902ce780ca32205f1622f1fa1649",
+    "zh:e100ad439313db667a5c4ca53ae4c54d8b1c72299a2240a1493823cb89cb0781",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+  ]
+}

--- a/terraform/proxmox/proxmox-001/garage-s3/backend.tf
+++ b/terraform/proxmox/proxmox-001/garage-s3/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "pg" {
+    schema_name = "tf_proxmox_001_garage_s3"
+  }
+}

--- a/terraform/proxmox/proxmox-001/garage-s3/main.tf
+++ b/terraform/proxmox/proxmox-001/garage-s3/main.tf
@@ -1,0 +1,17 @@
+module "garage_s3_lxc" {
+  source = "../../../modules/proxmox-lxc"
+
+  container_name = "garage-s3"
+  target_node    = "proxmox-001"
+  os_template    = "local:vztmpl/debian-12-standard.tar.gz"
+
+  cores          = 2
+  memory         = 2048
+  rootfs_size    = "16G"
+  rootfs_storage = "vmstore"
+
+  nfs_server      = "192.168.1.21"
+  nfs_path        = "/volume1/homelab/garage-data"
+  nfs_mount_point = "/mnt/garage-data"
+  nfs_storage     = null
+}

--- a/terraform/proxmox/proxmox-001/garage-s3/output.tf
+++ b/terraform/proxmox/proxmox-001/garage-s3/output.tf
@@ -1,0 +1,9 @@
+output "container_id" {
+  description = "The LXC container ID"
+  value       = module.garage_s3_lxc.container_id
+}
+
+output "container_name" {
+  description = "The LXC container name"
+  value       = module.garage_s3_lxc.container_name
+}


### PR DESCRIPTION
## Summary

Deploys Garage S3 (Rust-based S3-compatible object storage) to Proxmox LXC container with Synology NFS backing storage.

### Changes

**Terraform:**
- New `proxmox-lxc` module using BPG provider (`proxmox_virtual_environment_container`)
- Garage S3 instance configuration at `terraform/proxmox/proxmox-001/garage-s3/`
- NFS mount to Synology NAS (`192.168.1.21:/volume1/homelab/garage-data`)

**Ansible:**
- New `garage_s3` role for installation and configuration
- Systemd service for Garage S3 daemon
- Configuration template for Garage S3 cluster

### Resources

| Resource | Value |
|----------|-------|
| CPU | 2 cores |
| Memory | 2GB |
| Rootfs | 16G on vmstore |
| NFS Mount | /mnt/garage-data |
| S3 API Port | 3900 |

### Prerequisites

1. Create NFS directory on Synology: `/volume1/homelab/garage-data`
2. Download Debian 12 template: `pveam download local debian-12-standard`
3. Configure NFS export with `rw,no_root_squash,async`

### Verification

```bash
# Provision LXC
cd terraform/proxmox/proxmox-001/garage-s3
terraform init -reconfigure
terraform apply

# Configure Garage S3
ansible-playbook ansible/playbooks/garage-s3.yml

# Test S3 endpoint
curl http://<garage-s3-ip>:3900
```

## Test plan

- [ ] Terraform plan/apply succeeds
- [ ] LXC container starts on Proxmox
- [ ] NFS mount accessible at `/mnt/garage-data`
- [ ] Garage S3 service running
- [ ] S3 API responds on port 3900
- [ ] Can create/list S3 buckets

🤖 Generated with [Claude Code](https://claude.com/claude-code)