### PR TITLE
refactor: remove Garage S3 variables from Proxmox LXC module

### DIFF
--- a/terraform/modules/proxmox-lxc/main.tf
+++ b/terraform/modules/proxmox-lxc/main.tf
@@ -44,14 +44,4 @@ resource "proxmox_lxc" "this" {
     }
   }
 
-  # Pass secrets via environment for cloud-init templating
-  dynamic "environment" {
-    for_each = (var.garage_admin_secret != "" && var.garage_api_secret != "") ? [1] : []
-    content {
-      env = {
-        GARAGE_ADMIN_SECRET = var.garage_admin_secret
-        GARAGE_API_SECRET   = var.garage_api_secret
-      }
-    }
-  }
 }

--- a/terraform/modules/proxmox-lxc/variables.tf
+++ b/terraform/modules/proxmox-lxc/variables.tf
@@ -78,16 +78,3 @@ variable "cloud_init_script" {
   default     = ""
 }
 
-variable "garage_admin_secret" {
-  type        = string
-  description = "Garage admin secret key"
-  default     = ""
-  sensitive   = true
-}
-
-variable "garage_api_secret" {
-  type        = string
-  description = "Garage API secret key"
-  default     = ""
-  sensitive   = true
-}


### PR DESCRIPTION
## Summary
- Removes unused `garage_admin_secret` and `garage_api_secret` variables
- Removes the dynamic `environment` block that passed Garage secrets to containers

## Why
These variables were added for Garage S3 integration but are no longer needed.