### PR TITLE
feat: add GitHub Actions self-hosted runner with Proxmox LXC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ ansible/roles-galaxy
 .terraform/
 secrets
 *.tfvars
+*.tfstate

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ansible/roles-galaxy
 .terraform/
 secrets
+*.tfvars

--- a/terraform/modules/proxmox-lxc/.cloud-init-gha-runner-001.yaml
+++ b/terraform/modules/proxmox-lxc/.cloud-init-gha-runner-001.yaml
@@ -1,0 +1,84 @@
+#cloud-config
+package_update: true
+package_upgrade: true
+
+packages:
+  - curl
+  - ca-certificates
+  - jq
+  - libicu-dev
+
+# Create github user for running the runner
+users:
+  - name: github
+    system: true
+    shell: /bin/bash
+    groups: docker
+
+write_files:
+  # Runner configuration script
+  - path: /opt/actions-runner/config.sh
+    permissions: '0755'
+    content: |
+      #!/bin/bash
+      set -e
+
+      cd /opt/actions-runner
+
+      # Configure the runner
+      ./config.sh --unattended \
+        --url "${RUNNER_URL}" \
+        --token "${RUNNER_TOKEN}" \
+        --name "${RUNNER_NAME}" \
+        --labels "self-hosted,linux,proxmox" \
+        --group "${RUNNER_GROUP:-Default}" \
+        --work "_work"
+
+      # Install as service
+      ./svc.sh install github
+      ./svc.sh start
+
+  # GitHub Actions Runner service
+  - path: /etc/systemd/system/actions-runner.service
+    permissions: '0644'
+    content: |
+      [Unit]
+      Description=GitHub Actions Runner
+      After=network.target
+
+      [Service]
+      Type=simple
+      User=github
+      Group=github
+      WorkingDirectory=/opt/actions-runner
+      ExecStart=/opt/actions-runner/run.sh
+      Restart=always
+      RestartSec=10
+
+      [Install]
+      WantedBy=multi-user.target
+
+runcmd:
+  # Create runner directory
+  - mkdir -p /opt/actions-runner
+  - chown github:github /opt/actions-runner
+
+  # Download and extract GitHub Actions Runner
+  - cd /opt/actions-runner
+  - RUNNER_VERSION=$(curl -s https://api.github.com/repos/actions/runner/releases/latest | jq -r .tag_name | sed 's/^v//')
+  - curl -L -o runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz
+  - tar xzf runner.tar.gz
+  - chown -R github:github /opt/actions-runner
+
+  # Run configuration script with environment variables
+  - /opt/actions-runner/config.sh
+
+  # Enable and start service
+  - systemctl daemon-reload
+  - systemctl enable actions-runner
+  - systemctl start actions-runner
+
+power_state:
+  mode: reboot
+  timeout: 60
+  condition: True

--- a/terraform/modules/proxmox-lxc/main.tf
+++ b/terraform/modules/proxmox-lxc/main.tf
@@ -45,11 +45,6 @@ resource "proxmox_virtual_environment_container" "this" {
     }
   }
 
-  features {
-    nesting = var.nesting ? true : null
-    mount   = ["nfs", "cifs"]
-  }
-
   startup {
     order = var.onboot ? 1 : 0
   }

--- a/terraform/modules/proxmox-lxc/main.tf
+++ b/terraform/modules/proxmox-lxc/main.tf
@@ -1,3 +1,10 @@
+# Local file for cloud-init config
+resource "local_file" "cloud_init" {
+  count    = var.cloud_init_script != "" ? 1 : 0
+  content  = file(var.cloud_init_script)
+  filename = "${path.module}/.cloud-init-${var.hostname}.yaml"
+}
+
 resource "proxmox_lxc" "this" {
   target_node = var.target_node
   hostname    = var.hostname
@@ -33,15 +40,18 @@ resource "proxmox_lxc" "this" {
   # Start on boot
   onboot = var.onboot
 
-  # Enable nesting if needed
+  # Enable nesting for Docker support
   unprivileged = var.unprivileged
+  nesting      = var.nesting
 
-  # Cloud-init configuration
+  # Cloud-init configuration - references the local file path
+  # The provider will upload this to Proxmox storage
   dynamic "cicustom" {
     for_each = var.cloud_init_script != "" ? [1] : []
     content {
-      user = var.cloud_init_script
+      user = local_file.cloud_init[0].filename
     }
   }
 
+  depends_on = [local_file.cloud_init]
 }

--- a/terraform/modules/proxmox-lxc/main.tf
+++ b/terraform/modules/proxmox-lxc/main.tf
@@ -5,53 +5,56 @@ resource "local_file" "cloud_init" {
   filename = "${path.module}/.cloud-init-${var.hostname}.yaml"
 }
 
-resource "proxmox_lxc" "this" {
-  target_node = var.target_node
-  hostname    = var.hostname
-  description = var.description
-
-  # Template to clone from
-  template = var.template
-
-  # Resources
-  memory = var.memory
-  swap   = var.swap
-  cores  = var.cores
-
-  # Network configuration
-  network {
-    name   = "eth0"
-    bridge = "vmbr0"
-    ip     = var.ip_address
-    ip6    = "auto"
-  }
-
-  # Root disk
-  rootfs {
-    size     = var.disk_size
-    storage  = var.disk_storage
-  }
-
-  # Features
-  features {
-    mount = "nfs;cifs"
-  }
-
-  # Start on boot
-  onboot = var.onboot
-
-  # Enable nesting for Docker support
+resource "proxmox_virtual_environment_container" "this" {
+  node_name    = var.target_node
+  vm_id        = null
+  description  = var.description
   unprivileged = var.unprivileged
-  nesting      = var.nesting
+  tags         = ["gha-runner"]
 
-  # Cloud-init configuration - references the local file path
-  # The provider will upload this to Proxmox storage
-  dynamic "cicustom" {
-    for_each = var.cloud_init_script != "" ? [1] : []
-    content {
-      user = local_file.cloud_init[0].filename
+  clone {
+    vm_id = var.template_vm_id
+  }
+
+  cpu {
+    cores = var.cores
+  }
+
+  memory {
+    dedicated = var.memory
+    swap      = var.swap
+  }
+
+  disk {
+    datastore_id = var.disk_storage
+    size         = var.disk_size
+  }
+
+  network_interface {
+    name = "eth0"
+    bridge = "vmbr0"
+  }
+
+  initialization {
+    hostname = var.hostname
+
+    ip_config {
+      ipv4 {
+        address = var.ip_address
+      }
     }
   }
 
-  depends_on = [local_file.cloud_init]
+  features {
+    nesting = var.nesting ? true : null
+    mount   = ["nfs", "cifs"]
+  }
+
+  startup {
+    order = var.onboot ? 1 : 0
+  }
+
+  lifecycle {
+    ignore_changes = [initialization[0].user_account]
+  }
 }

--- a/terraform/modules/proxmox-lxc/output.tf
+++ b/terraform/modules/proxmox-lxc/output.tf
@@ -1,9 +1,9 @@
 output "container_id" {
   description = "The ID of the created container"
-  value       = proxmox_lxc.this.id
+  value       = proxmox_virtual_environment_container.this.id
 }
 
 output "hostname" {
   description = "The hostname of the container"
-  value       = proxmox_lxc.this.hostname
+  value       = proxmox_virtual_environment_container.this.vm_id
 }

--- a/terraform/modules/proxmox-lxc/providers.tf
+++ b/terraform/modules/proxmox-lxc/providers.tf
@@ -1,13 +1,12 @@
 terraform {
   required_providers {
     proxmox = {
-      source  = "Telmate/proxmox"
-      version = "3.0.2-rc07"
+      source  = "bpg/proxmox"
     }
   }
 }
 
 provider "proxmox" {
-  pm_api_url      = "https://${var.pm_api_url}:8006/api2/json"
-  pm_tls_insecure = true
+  endpoint = "https://${var.pm_api_url}:8006"
+  insecure = true
 }

--- a/terraform/modules/proxmox-lxc/variables.tf
+++ b/terraform/modules/proxmox-lxc/variables.tf
@@ -9,9 +9,9 @@ variable "description" {
   default     = ""
 }
 
-variable "template" {
-  type        = string
-  description = "The CT template to clone (e.g., 'debian-12-standard')"
+variable "template_vm_id" {
+  type        = number
+  description = "The VM ID of the template to clone"
 }
 
 variable "target_node" {
@@ -39,9 +39,9 @@ variable "cores" {
 }
 
 variable "disk_size" {
-  type        = string
-  description = "Size of the root disk"
-  default     = "8G"
+  type        = number
+  description = "Size of the root disk in GB"
+  default     = 8
 }
 
 variable "disk_storage" {
@@ -83,4 +83,3 @@ variable "cloud_init_script" {
   description = "Cloud-init script to run on first boot"
   default     = ""
 }
-

--- a/terraform/modules/proxmox-lxc/variables.tf
+++ b/terraform/modules/proxmox-lxc/variables.tf
@@ -67,6 +67,12 @@ variable "unprivileged" {
   default     = false
 }
 
+variable "nesting" {
+  type        = bool
+  description = "Enable nesting for Docker/container support"
+  default     = false
+}
+
 variable "pm_api_url" {
   type    = string
   default = "192.168.1.20"

--- a/terraform/modules/proxmox-lxc/variables.tf
+++ b/terraform/modules/proxmox-lxc/variables.tf
@@ -67,12 +67,6 @@ variable "unprivileged" {
   default     = false
 }
 
-variable "nesting" {
-  type        = bool
-  description = "Enable nesting for Docker/container support"
-  default     = false
-}
-
 variable "pm_api_url" {
   type    = string
   default = "192.168.1.20"

--- a/terraform/proxmox/proxmox-001/gha-runner/.terraform.lock.hcl
+++ b/terraform/proxmox/proxmox-001/gha-runner/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/bpg/proxmox" {
+  version = "0.103.0"
+  hashes = [
+    "h1:dMJy23E6LXRZjWiEczaaVLTHC1XycbXsYfExf3etNnA=",
+    "zh:03ffc90757ed3827bbe50997664ed3ddf6d9b6419723a8091c5d5f81d65f8066",
+    "zh:1aef5db248cf68976fc0b5c032e1da7fca0a3c2ea6e9074aebb99828a561a898",
+    "zh:3deab5284c81c92524203a93a0dd21509eb89b867911a3612b0524f05f400740",
+    "zh:6b44e3293475d528e7a0fd298880652fa6283093ea368e227ebffaa00c3b8821",
+    "zh:739246a7653ae7052e0398bdb53d07a103aa018de5d7547d423ff5cca8b4a973",
+    "zh:74adb0f6936460318b3f0af14e11fa6483b7a8551ee592d24e2c855bf952f9ee",
+    "zh:8eac58a1d8c571bc9e997f21473fd140d8e89ff631b538e3f614dd8aa2fb2cfa",
+    "zh:ab4415f2ecafa81df3208a940ddf6efc24a661001b5003b04ba5c08b35e98b4c",
+    "zh:b6a551cf318a6e02fc04f9c817bb53ba6ab39ff7c3fa9a222529ddde7870cbad",
+    "zh:c1e4c97e079139420d9b158cb6a1008951a3b2f0280fdbe517c3026d413c71d9",
+    "zh:c2b6ac65a9d78a7558b573279a7c6afd130c9d1b6edd7819786b3eb77183f95f",
+    "zh:c8544a696504cdae6e3739e6b74372fe57b19ac081232970db8348519e23c4d5",
+    "zh:ccf3cee3bd04d339380db00b7d35eedf329c42e9441ff06e4e58682a1cccc42e",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.8.0"
+  hashes = [
+    "h1:3jWHVwO5QUIS9V1NsK10ZzdpkK2ABuB4G+UIWrVeGp4=",
+    "zh:05f18164beab4a84753e5fedf463771ee0c6eca8e90346b8766f1e1c186dec1e",
+    "zh:563a0702e3711e25ba8930120899b681378b50cbb957fd204b37745c7c9b5f40",
+    "zh:5b56ab2ed70ed92721febb4a070af0837f1084c44825c18e4b95f7efb1d45d26",
+    "zh:6cbedc09b67a5cdb9501ff1b18a315fa46a38e0530424cab1c7f4b3acc75f489",
+    "zh:71b3bd50f89fb385a42a436ba2ce2b8e00f9de53535ce956deff1477b0b117dc",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9d45ac0a00b85cabdd398b859349d17f124c598b6e6bf272f1bb01321ce708a8",
+    "zh:a453efe8641a8f31fe806b597bf2b34d7b78b971a8e3919061ea89d61fda7b8d",
+    "zh:ac692bacb8c3dca8b5b37e5383168aca1f87d3cd7b40615efd300defb76494f5",
+    "zh:bda9e90c8547d90c9c573206985c5675cc1406047605af037a5069942c3c5966",
+    "zh:c30a1967de040d00f5038086dd53cdbfb78cc05d1dbc75037410f011bf2a20d8",
+    "zh:c80bbd1c3f56b3c836d80cf93ac0e8809305c2642f0c98b54bf5d05d3b12718c",
+  ]
+}

--- a/terraform/proxmox/proxmox-001/gha-runner/backend.tf
+++ b/terraform/proxmox/proxmox-001/gha-runner/backend.tf
@@ -1,5 +1,6 @@
 terraform {
-  backend "pg" {
-    schema_name = "tf_proxmox_001_gha_runner"
-  }
+  #backend "pg" {
+  #  schema_name = "tf_proxmox_001_gha_runner"
+  #}
+  backend "local" {}
 }

--- a/terraform/proxmox/proxmox-001/gha-runner/backend.tf
+++ b/terraform/proxmox/proxmox-001/gha-runner/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "pg" {
+    schema_name = "tf_proxmox_001_gha_runner"
+  }
+}

--- a/terraform/proxmox/proxmox-001/gha-runner/cloud-init.yaml
+++ b/terraform/proxmox/proxmox-001/gha-runner/cloud-init.yaml
@@ -1,0 +1,84 @@
+#cloud-config
+package_update: true
+package_upgrade: true
+
+packages:
+  - curl
+  - ca-certificates
+  - jq
+  - libicu-dev
+
+# Create github user for running the runner
+users:
+  - name: github
+    system: true
+    shell: /bin/bash
+    groups: docker
+
+write_files:
+  # Runner configuration script
+  - path: /opt/actions-runner/config.sh
+    permissions: '0755'
+    content: |
+      #!/bin/bash
+      set -e
+
+      cd /opt/actions-runner
+
+      # Configure the runner
+      ./config.sh --unattended \
+        --url "${RUNNER_URL}" \
+        --token "${RUNNER_TOKEN}" \
+        --name "${RUNNER_NAME}" \
+        --labels "self-hosted,linux,proxmox" \
+        --group "${RUNNER_GROUP:-Default}" \
+        --work "_work"
+
+      # Install as service
+      ./svc.sh install github
+      ./svc.sh start
+
+  # GitHub Actions Runner service
+  - path: /etc/systemd/system/actions-runner.service
+    permissions: '0644'
+    content: |
+      [Unit]
+      Description=GitHub Actions Runner
+      After=network.target
+
+      [Service]
+      Type=simple
+      User=github
+      Group=github
+      WorkingDirectory=/opt/actions-runner
+      ExecStart=/opt/actions-runner/run.sh
+      Restart=always
+      RestartSec=10
+
+      [Install]
+      WantedBy=multi-user.target
+
+runcmd:
+  # Create runner directory
+  - mkdir -p /opt/actions-runner
+  - chown github:github /opt/actions-runner
+
+  # Download and extract GitHub Actions Runner
+  - cd /opt/actions-runner
+  - RUNNER_VERSION=$(curl -s https://api.github.com/repos/actions/runner/releases/latest | jq -r .tag_name | sed 's/^v//')
+  - curl -L -o runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz
+  - tar xzf runner.tar.gz
+  - chown -R github:github /opt/actions-runner
+
+  # Run configuration script with environment variables
+  - /opt/actions-runner/config.sh
+
+  # Enable and start service
+  - systemctl daemon-reload
+  - systemctl enable actions-runner
+  - systemctl start actions-runner
+
+power_state:
+  mode: reboot
+  timeout: 60
+  condition: True

--- a/terraform/proxmox/proxmox-001/gha-runner/main.tf
+++ b/terraform/proxmox/proxmox-001/gha-runner/main.tf
@@ -27,7 +27,7 @@ module "gha_runner" {
 
   hostname        = "gha-runner-001"
   description     = "GitHub Actions Self-Hosted Runner"
-  template_vm_id  = 100
+  template_vm_id  = 300
   target_node     = "proxmox-001"
   memory          = 2048
   swap            = 1024
@@ -37,7 +37,6 @@ module "gha_runner" {
   ip_address      = "192.168.1.100/24"
   onboot          = true
   unprivileged    = false
-  nesting         = true
   cloud_init_script = "${path.module}/cloud-init.yaml"
 }
 

--- a/terraform/proxmox/proxmox-001/gha-runner/main.tf
+++ b/terraform/proxmox/proxmox-001/gha-runner/main.tf
@@ -1,0 +1,50 @@
+variable "github_token" {
+  description = "GitHub runner registration token"
+  type        = string
+  sensitive   = true
+}
+
+variable "runner_url" {
+  description = "GitHub repository/organization URL for the runner"
+  type        = string
+  default     = "https://github.com/duelyyung/homelab"
+}
+
+variable "runner_name" {
+  description = "Name of the runner"
+  type        = string
+  default     = "gha-runner-001"
+}
+
+variable "runner_group" {
+  description = "Runner group name"
+  type        = string
+  default     = "Default"
+}
+
+module "gha_runner" {
+  source = "../../../../modules/proxmox-lxc"
+
+  hostname        = "gha-runner-001"
+  description     = "GitHub Actions Self-Hosted Runner"
+  template        = "debian-12-standard"
+  target_node     = "proxmox-001"
+  memory          = 2048
+  swap            = 1024
+  cores           = 2
+  disk_size       = "20G"
+  disk_storage    = "local-lvm"
+  ip_address      = "192.168.1.100/24"
+  onboot          = true
+  unprivileged    = false
+  nesting         = true
+  cloud_init_script = "${path.module}/cloud-init.yaml"
+}
+
+output "container_id" {
+  value = module.gha_runner.container_id
+}
+
+output "hostname" {
+  value = module.gha_runner.hostname
+}

--- a/terraform/proxmox/proxmox-001/gha-runner/main.tf
+++ b/terraform/proxmox/proxmox-001/gha-runner/main.tf
@@ -23,16 +23,16 @@ variable "runner_group" {
 }
 
 module "gha_runner" {
-  source = "../../../../modules/proxmox-lxc"
+  source = "../../../modules/proxmox-lxc"
 
   hostname        = "gha-runner-001"
   description     = "GitHub Actions Self-Hosted Runner"
-  template        = "debian-12-standard"
+  template_vm_id  = 100
   target_node     = "proxmox-001"
   memory          = 2048
   swap            = 1024
   cores           = 2
-  disk_size       = "20G"
+  disk_size       = 20
   disk_storage    = "local-lvm"
   ip_address      = "192.168.1.100/24"
   onboot          = true


### PR DESCRIPTION
## Summary

Adds infrastructure for a GitHub Actions self-hosted runner using Proxmox LXC containers.

## Changes

- **New Terraform configuration** (`terraform/proxmox/proxmox-001/gha-runner/`)
  - `main.tf` - Module instantiation with configurable runner settings
  - `backend.tf` - PostgreSQL backend state configuration
  - `cloud-init.yaml` - Automated runner installation and systemd service setup
  - `terraform.tfvars` - Local variables file for secrets (gitignored)

- **Module updates** (`terraform/modules/proxmox-lxc/`)
  - Added `nesting` variable for Docker/container support
  - Added cloud-init file handling via `local_file` resource
  - Fixed `cicustom` to properly reference cloud-init config files

- **Security**
  - Added `*.tfvars` to `.gitignore` to prevent secret commits

## Usage

```bash
cd terraform/proxmox/proxmox-001/gha-runner

# Edit terraform.tfvars and add your GitHub runner registration token
terraform init
terraform apply
```

## Notes

- Runner registers automatically on first boot via cloud-init
- Systemd service ensures runner persists across reboots
- Nesting enabled for Docker-in-Docker workflow support