### PR TITLE
feat(synology): garage s3

### DIFF
--- a/synology/garage-synology-docker-compose.yaml
+++ b/synology/garage-synology-docker-compose.yaml
@@ -1,0 +1,22 @@
+# Docker Compose file to run Garage on Synology DSM Container Manager
+#
+# Requires manual configuration (https://garagehq.deuxfleurs.fr/documentation/quick-start/#manual-configuration)
+# Enable SSH on Synology DSM to run the garage cli from the container
+
+services:
+  garage:
+    image: dxflrs/garage:b6b18427a5fc9b5b7540cf6d0843afd5cf7f9b56
+    container_name: garage
+    environment:
+      - RUST_LOG=garage=info
+    ports:
+      - '3900:3900'  # s3 api
+    #  - '3901:3901'  # rpc bind
+      - '3902:3902'  # s3 web
+    #  - '3903:3903'  # admin
+    restart: unless-stopped
+    stop_grace_period: 2m
+    volumes:
+      - /volume1/docker/garage/garage.toml:/etc/garage.toml
+      - /volume1/docker/garage/meta:/var/lib/garage/meta
+      - /volume1/docker/garage/data:/var/lib/garage/data

--- a/synology/garage.toml
+++ b/synology/garage.toml
@@ -1,0 +1,24 @@
+metadata_dir = "/var/lib/garage/meta"
+data_dir = "/var/lib/garage/data"
+db_engine = "sqlite"
+
+replication_factor = 1
+
+rpc_bind_addr = "[::]:3901"
+rpc_public_addr = "127.0.0.1:3901"
+rpc_secret = "${GARAGE_RPC_SECRET}"
+
+[s3_api]
+s3_region = "garage"
+api_bind_addr = "[::]:3900"
+root_domain = ".s3.garage.localhost"
+
+[s3_web]
+bind_addr = "[::]:3902"
+root_domain = ".web.garage.localhost"
+index = "index.html"
+
+[admin]
+api_bind_addr = "[::]:3903"
+admin_token = "${GARAGE_ADMIN_TOKEN}"
+metrics_token = "${GARAGE_METRICS_TOKEN}"

--- a/synology/garage.toml
+++ b/synology/garage.toml
@@ -9,7 +9,7 @@ rpc_public_addr = "127.0.0.1:3901"
 rpc_secret = "${GARAGE_RPC_SECRET}"
 
 [s3_api]
-s3_region = "garage"
+s3_region = "us-east-1"
 api_bind_addr = "[::]:3900"
 root_domain = ".s3.garage.localhost"
 


### PR DESCRIPTION
Use Synology Container Manager to launch Garage S3

The toml file was manually copied over to `/volume1/docker/garage/garage.toml`