### PR TITLE
feat: add Unbound DNS container

### DIFF
--- a/terraform/synology/containers/unbound/backend.tf
+++ b/terraform/synology/containers/unbound/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}

--- a/terraform/synology/containers/unbound/main.tf
+++ b/terraform/synology/containers/unbound/main.tf
@@ -1,0 +1,39 @@
+module "unbound" {
+  source = "../../../modules/synology-container"
+
+  name = "unbound"
+  run  = true
+
+  services = {
+    unbound = {
+      image = "mvout/unbound:latest"
+
+      ports = [
+        {
+          target    = 53
+          published = "53"
+        }
+      ]
+
+      volumes = [
+        {
+          type   = "volume"
+          source = "unbound-data"
+          target = "/opt/unbound/etc/unbound"
+        }
+      ]
+    }
+  }
+
+  volumes = {
+    unbound-data = {
+      driver = "local"
+    }
+  }
+
+  networks = {
+    unbound-network = {
+      driver = "bridge"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Added new Terraform project for Unbound DNS in `terraform/synology/containers/unbound`
- Utilizes the existing `synology-container` module
- Configures port 53 and persistent volume for Unbound data

## Test plan
- [ ] Run `terraform apply` in the unbound directory
- [ ] Verify container is running in Synology Container Manager
- [ ] Test DNS resolution via `dig @<synology-ip> google.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)