### PR TITLE
chore(unbound): add synology service records to unbound

### DIFF
--- a/terraform/synology/containers/unbound/unbound-records.conf
+++ b/terraform/synology/containers/unbound/unbound-records.conf
@@ -28,12 +28,14 @@ server:
   use-caps-for-id: yes
 
   # Local records — internal hostnames
-  local-zone: "home.arpa." static
-  local-data: "nas.home.arpa. IN A 192.168.1.21"
+  local-zone: "internal." static
+  local-data: "nas.internal. IN A 192.168.1.21"
+  local-data: "plex.internal. IN A 192.168.1.21"
+  local-data: "photos.internal. IN A 192.168.1.21"
 
   # Reverse DNS for your subnet
   local-zone: "1.168.192.in-addr.arpa." static
-  local-data-ptr: "192.168.1.21 nas.home.arpa"
+  local-data-ptr: "192.168.1.21 nas.internal"
 
 # Forward all other queries upstream (e.g. Cloudflare or your ISP)
 forward-zone:


### PR DESCRIPTION
- Use .internal as the TLD
- Add Synology derive A records to unbound