### PR TITLE
feat: add Caddy reverse proxy on Synology

### DIFF
--- a/terraform/synology/containers/caddy/Caddyfile
+++ b/terraform/synology/containers/caddy/Caddyfile
@@ -1,0 +1,13 @@
+# Caddyfile for Synology Reverse Proxy
+
+nas.internal {
+    reverse_proxy 192.168.1.21:5000
+}
+
+plex.internal {
+    reverse_proxy 192.168.1.21:32400
+}
+
+photos.internal {
+    reverse_proxy 192.168.1.21:8081
+}

--- a/terraform/synology/containers/caddy/backend.tf
+++ b/terraform/synology/containers/caddy/backend.tf
@@ -1,0 +1,13 @@
+terraform {
+  backend "s3" {
+    endpoint = "http://192.168.1.21:3900"
+    bucket   = "terraform-state"
+    key      = "synology/containers/caddy/terraform.tfstate"
+    region   = "us-east-1"
+
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_requesting_account_id  = true
+    force_path_style            = true
+  }
+}

--- a/terraform/synology/containers/caddy/main.tf
+++ b/terraform/synology/containers/caddy/main.tf
@@ -1,0 +1,45 @@
+module "caddy" {
+  source = "../../../modules/synology-container"
+
+  name = "caddy"
+  run  = true
+
+  services = {
+    caddy = {
+      image   = "caddy:latest"
+      restart = "unless-stopped"
+
+      ports = [
+        {
+          target    = 80
+          protocol  = "tcp"
+          published = "80"
+        },
+        {
+          target    = 443
+          protocol  = "tcp"
+          published = "443"
+        }
+      ]
+
+      configs = [{
+        source = "caddyfile"
+        target = "/etc/caddy/Caddyfile"
+        mode   = "0644"
+      }]
+    }
+  }
+
+  configs = {
+    caddyfile = {
+      name    = "caddyfile"
+      content = file("Caddyfile")
+    }
+  }
+
+  networks = {
+    app-network = {
+      driver = "bridge"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add Caddy container configuration using the `synology-container` module.
- Configure reverse proxy rules for `nas.internal`, `plex.internal`, and `photos.internal` based on Unbound records.
- Set up S3 backend for terraform state.

## Test plan
- [ ] Run `terraform init` and `terraform apply` in `terraform/synology/containers/caddy/`.
- [ ] Verify Caddy container is running on Synology.
- [ ] Test access to `nas.internal`, `plex.internal`, and `photos.internal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)