### PR TITLE
feat(synology): deploy dozzle to port 9999

### DIFF
--- a/terraform/modules/synology-container/providers.tf
+++ b/terraform/modules/synology-container/providers.tf
@@ -1,3 +1,3 @@
 provider "synology" {
-  host     = "https://192.168.1.21:5001"
+  host = "https://192.168.1.21:5001"
 }

--- a/terraform/modules/synology-container/variables.tf
+++ b/terraform/modules/synology-container/variables.tf
@@ -10,10 +10,11 @@ variable "run" {
 variable "services" {
   type = map(object({
     image       = string
-    ports       = optional(list(object({ target = number, protocol = string, published = string })))
+    restart     = optional(string)
+    ports       = optional(list(object({ target = number, protocol = optional(string), published = string })))
     environment = optional(map(string))
     volumes     = optional(list(object({ type = string, source = string, target = string })))
-    configs     = optional(list(object({ source = string, target = string })))
+    configs     = optional(list(object({ source = string, target = string, mode = optional(string) })))
   }))
 }
 

--- a/terraform/modules/synology-container/version.tf
+++ b/terraform/modules/synology-container/version.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     synology = {
-      source  = "synology-community/synology"
+      source = "synology-community/synology"
       #version = "0.6.11-local"
       version = "= 0.6.7"
     }

--- a/terraform/synology/containers/dozzle/.terraform.lock.hcl
+++ b/terraform/synology/containers/dozzle/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/synology-community/synology" {
+  version     = "0.6.7"
+  constraints = "0.6.7"
+  hashes = [
+    "h1:XOgx4rcmKseGBsNOWSEt0cOOrzSQrWDleoUhsejAHUo=",
+    "zh:04666de2627d71271cc3b0d53941d5344384586b01a9a968e0403a677d7ed718",
+    "zh:0549b76e9d0a4c9705ef0e90bc64964a268453f99f5ba7f2eb4ce804b1d621c4",
+    "zh:3566bef878f5af3847811d4538270a1c3bf00f43993b6cb9dae9172500c9a88a",
+    "zh:52737dd78cc63e06437cda279a26df9f00903a65c619965122ba0cdcfa44f98b",
+    "zh:6def51b1aedace1e50fae68fa5b9e1a53f224c68557beba32af0bf02d7b3c306",
+    "zh:6f794376c2a8e321d1060b15701d7b8d3953590bfe8f535b1e9e8a1136fc4ae1",
+    "zh:80a820efcd1ef3cfac9de75238771ae0edebe3b611d1b77a42aa1e0a3cbc5925",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:898a9b06cfaf9bce542aa62f14010244c4d522f9b9ccb94c1e6f56626a6550e6",
+    "zh:8f50599e64fe3fbf8fd092a3ebac15a3296a2404c0160d002af47ba63e334cd6",
+    "zh:b48bee6d86d05caeb7b69eef1af4f714d2525034759f555d30d3922999b5121b",
+    "zh:b5100c946986a8301a0711a3fe81049e14597e0be44aa3c6e41945662eb20a44",
+    "zh:bcf9a8bba33ea0da76fa3cf4318dee9cff57a0e56e66d44bae25933e1540c834",
+    "zh:f9cff5e8da1efe4716b70dfef5d5ace37ad22571f748516a39ea1a075e265401",
+    "zh:fbcae253a2e42e8d1e57de7921dc8dbad504da30eb91db6d0b2873efd969cbb9",
+  ]
+}

--- a/terraform/synology/containers/dozzle/backend.tf
+++ b/terraform/synology/containers/dozzle/backend.tf
@@ -1,10 +1,10 @@
 terraform {
   backend "s3" {
-    endpoint                    = "http://192.168.1.21:3900"
-    bucket                      = "terraform-state"
-    key                         = "synology/containers/dozzle/terraform.tfstate"
-    region                      = "us-east-1"
-  
+    endpoint = "http://192.168.1.21:3900"
+    bucket   = "terraform-state"
+    key      = "synology/containers/dozzle/terraform.tfstate"
+    region   = "us-east-1"
+
     skip_credentials_validation = true
     skip_metadata_api_check     = true
     skip_requesting_account_id  = true

--- a/terraform/synology/containers/dozzle/backend.tf
+++ b/terraform/synology/containers/dozzle/backend.tf
@@ -1,0 +1,13 @@
+terraform {
+  backend "s3" {
+    endpoint                    = "http://192.168.1.21:3900"
+    bucket                      = "terraform-state"
+    key                         = "synology/containers/dozzle/terraform.tfstate"
+    region                      = "us-east-1"
+  
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_requesting_account_id  = true
+    force_path_style            = true
+  }
+}

--- a/terraform/synology/containers/dozzle/main.tf
+++ b/terraform/synology/containers/dozzle/main.tf
@@ -1,0 +1,31 @@
+module "dozzle" {
+  source = "../../../modules/synology-container"
+
+  name = "dozzle"
+  run  = true
+
+  services = {
+    dozzle = {
+      image   = "amir20/dozzle:latest"
+      restart = "always"
+
+      ports = [{
+        target    = 8080
+        protocol  = "tcp"
+        published = "9999"
+      }]
+
+      volumes = [{
+        type   = "bind"
+        source = "/var/run/docker.sock"
+        target = "/var/run/docker.sock"
+      }]
+    }
+  }
+
+  networks = {
+    app-network = {
+      driver = "bridge"
+    }
+  }
+}

--- a/terraform/synology/containers/registry/.terraform.lock.hcl
+++ b/terraform/synology/containers/registry/.terraform.lock.hcl
@@ -2,9 +2,24 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/synology-community/synology" {
-  version     = "0.6.11-local"
-  constraints = "0.6.11-local"
+  version     = "0.6.7"
+  constraints = "0.6.7"
   hashes = [
-    "h1:PMq8f8y/shlLDLYOpus2EgeP+gAnSZEP98gEDmyjsnI=",
+    "h1:XOgx4rcmKseGBsNOWSEt0cOOrzSQrWDleoUhsejAHUo=",
+    "zh:04666de2627d71271cc3b0d53941d5344384586b01a9a968e0403a677d7ed718",
+    "zh:0549b76e9d0a4c9705ef0e90bc64964a268453f99f5ba7f2eb4ce804b1d621c4",
+    "zh:3566bef878f5af3847811d4538270a1c3bf00f43993b6cb9dae9172500c9a88a",
+    "zh:52737dd78cc63e06437cda279a26df9f00903a65c619965122ba0cdcfa44f98b",
+    "zh:6def51b1aedace1e50fae68fa5b9e1a53f224c68557beba32af0bf02d7b3c306",
+    "zh:6f794376c2a8e321d1060b15701d7b8d3953590bfe8f535b1e9e8a1136fc4ae1",
+    "zh:80a820efcd1ef3cfac9de75238771ae0edebe3b611d1b77a42aa1e0a3cbc5925",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:898a9b06cfaf9bce542aa62f14010244c4d522f9b9ccb94c1e6f56626a6550e6",
+    "zh:8f50599e64fe3fbf8fd092a3ebac15a3296a2404c0160d002af47ba63e334cd6",
+    "zh:b48bee6d86d05caeb7b69eef1af4f714d2525034759f555d30d3922999b5121b",
+    "zh:b5100c946986a8301a0711a3fe81049e14597e0be44aa3c6e41945662eb20a44",
+    "zh:bcf9a8bba33ea0da76fa3cf4318dee9cff57a0e56e66d44bae25933e1540c834",
+    "zh:f9cff5e8da1efe4716b70dfef5d5ace37ad22571f748516a39ea1a075e265401",
+    "zh:fbcae253a2e42e8d1e57de7921dc8dbad504da30eb91db6d0b2873efd969cbb9",
   ]
 }

--- a/terraform/synology/containers/registry/backend.tf
+++ b/terraform/synology/containers/registry/backend.tf
@@ -1,10 +1,10 @@
 terraform {
   backend "s3" {
-    endpoint                    = "http://192.168.1.21:3900"
-    bucket                      = "terraform-state"
-    key                         = "synology/containers/registry/terraform.tfstate"
-    region                      = "us-east-1"
-  
+    endpoint = "http://192.168.1.21:3900"
+    bucket   = "terraform-state"
+    key      = "synology/containers/registry/terraform.tfstate"
+    region   = "us-east-1"
+
     skip_credentials_validation = true
     skip_metadata_api_check     = true
     skip_requesting_account_id  = true

--- a/terraform/synology/containers/unbound/backend.tf
+++ b/terraform/synology/containers/unbound/backend.tf
@@ -1,10 +1,10 @@
 terraform {
   backend "s3" {
-    endpoint                    = "http://192.168.1.21:3900"
-    bucket                      = "terraform-state"
-    key                         = "synology/containers/unbound/terraform.tfstate"
-    region                      = "us-east-1"
-  
+    endpoint = "http://192.168.1.21:3900"
+    bucket   = "terraform-state"
+    key      = "synology/containers/unbound/terraform.tfstate"
+    region   = "us-east-1"
+
     skip_credentials_validation = true
     skip_metadata_api_check     = true
     skip_requesting_account_id  = true

--- a/terraform/synology/containers/unbound/main.tf
+++ b/terraform/synology/containers/unbound/main.tf
@@ -11,14 +11,14 @@ module "unbound" {
 
       ports = [
         {
-        target    = 53
-        protocol  = "tcp"
-        published = "53"
+          target    = 53
+          protocol  = "tcp"
+          published = "53"
         },
         {
-        target    = 53
-        protocol  = "udp"
-        published = "53"
+          target    = 53
+          protocol  = "udp"
+          published = "53"
         }
       ]
 


### PR DESCRIPTION
## Summary
This PR adds a new Terraform configuration to deploy Dozzle on Synology Container Manager.

### Changes
- Created terraform/synology/containers/dozzle/ with main.tf and backend.tf.
- Configured Dozzle to run on port 9999 and bind-mount /var/run/docker.sock.
- Updated terraform/modules/synology-container/variables.tf to support:
  - restart policy for services.
  - Optional protocol in port mappings.
  - mode for service configs.