### PR TITLE
feat(proxmox): add k3s-002 and cloud-init support to vm module

### DIFF
--- a/ansible/roles/apt/tasks/main.yml
+++ b/ansible/roles/apt/tasks/main.yml
@@ -9,3 +9,4 @@
       - net-tools
       - sudo
       - curl
+      - cloud-init

--- a/terraform/modules/proxmox-vm/main.tf
+++ b/terraform/modules/proxmox-vm/main.tf
@@ -6,6 +6,19 @@ data "proxmox_virtual_environment_vms" "template" {
   }
 }
 
+resource "proxmox_virtual_environment_file" "user_data" {
+  count = var.user_data != null ? 1 : 0
+
+  content_type = "snippets"
+  datastore_id = var.snippet_storage
+  node_name    = var.target_node
+
+  source_raw {
+    data      = var.user_data
+    file_name = "${var.vm_name}-user-data.yaml"
+  }
+}
+
 resource "proxmox_virtual_environment_vm" "this" {
   name        = var.vm_name
   description = var.vm_desc
@@ -34,6 +47,11 @@ resource "proxmox_virtual_environment_vm" "this" {
     interface    = "scsi0"
     size         = parseint(replace(var.disk_size, "G", ""), 10)
     backup       = var.disk_backup
+  }
+
+  initialization {
+    datastore_id      = var.disk_storage
+    user_data_file_id = var.user_data != null ? proxmox_virtual_environment_file.user_data[0].id : null
   }
 
   dynamic "clone" {

--- a/terraform/modules/proxmox-vm/providers.tf
+++ b/terraform/modules/proxmox-vm/providers.tf
@@ -10,4 +10,9 @@ terraform {
 provider "proxmox" {
   endpoint = "https://${var.pm_api_url}:8006/"
   insecure = true
+
+  ssh {
+    agent    = true
+    username = "root"
+  }
 }

--- a/terraform/modules/proxmox-vm/variables.tf
+++ b/terraform/modules/proxmox-vm/variables.tf
@@ -55,3 +55,15 @@ variable "disk_backup" {
   type    = bool
   default = true
 }
+
+variable "user_data" {
+  type        = string
+  description = "The cloud-init user data"
+  default     = null
+}
+
+variable "snippet_storage" {
+  type        = string
+  description = "The name of the storage pool on which to store the cloud-init snippets"
+  default     = "local"
+}

--- a/terraform/proxmox/proxmox-001/k3s-002/.terraform.lock.hcl
+++ b/terraform/proxmox/proxmox-001/k3s-002/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/bpg/proxmox" {
+  version     = "0.104.0"
+  constraints = "~> 0.104.0"
+  hashes = [
+    "h1:ZPJiS5x4ycum7gPKFvV/WeJu7I3E826dcyCl9CtVm4I=",
+    "zh:0690742b1db878941efd816fe49fa08a5814f11f83db7cdbdf147e516471e9f8",
+    "zh:2865fbf6bdb240793fd2f868b62f69c8316a49a6d54f1d0c2be383a0a7af52ce",
+    "zh:29dcf11addaa01defd6e9617594ceb68c025d9e56cc7b75085d2bf5533e6c9de",
+    "zh:38c453e0cd52d686fc0875ecf8ba527b7861beec74e88038c6e98c8e9fcbc44f",
+    "zh:3a850a7b2474b11384d0bd610fdab404e9d23a2e93689f47eadb549fb38de741",
+    "zh:4a463a50741dbfdf295bd07dfba060f67b6bbc4a0f772cda8be4c5bd13d41807",
+    "zh:5888bb23c540014901aee8579ef1666de12275226820e92c204d8da727e0fcbc",
+    "zh:6154fc077075fc7b97e1f1feb3a9c9e0da3c1b67a46a86dbbf76c49b28583112",
+    "zh:6cc5ecb96693ebb01a0409630b9a55ac154289920a6fb561925d9a805f93714e",
+    "zh:b57dad6e778cd80b1c9ccb251a5d59a7f4270ad2ad585b687de5189b84efe683",
+    "zh:b5dfa2d3781c5ff53a2fc38ba61095a6fb135b39a5ad20fb0a15ae2587d908a8",
+    "zh:c9901182104d47bc9274280bd8428f71c5879177af6648ae162cde6217b456f1",
+    "zh:ea54d1f9a4a57d745d1f8ab3be1bb0b836d046605d55afc57840faea6d6dc402",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+  ]
+}

--- a/terraform/proxmox/proxmox-001/k3s-002/backend.tf
+++ b/terraform/proxmox/proxmox-001/k3s-002/backend.tf
@@ -1,0 +1,13 @@
+terraform {
+  backend "s3" {
+    endpoint = "http://192.168.1.21:3900"
+    bucket   = "terraform-state"
+    key      = "proxmox/proxmox-001/k3s-002/terraform.tfstate"
+    region   = "us-east-1"
+
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_requesting_account_id  = true
+    force_path_style            = true
+  }
+}

--- a/terraform/proxmox/proxmox-001/k3s-002/main.tf
+++ b/terraform/proxmox/proxmox-001/k3s-002/main.tf
@@ -1,0 +1,17 @@
+module "instance" {
+  source = "../../../modules/proxmox-vm"
+
+  vm_name           = "k3s-002"
+  vm_clone_template = "debian-12.13.0"
+  full_clone        = false
+
+  cores  = 2
+  memory = 4096
+
+  user_data = <<EOF
+#cloud-config
+runcmd:
+  - apt-get update && apt-get install -y curl
+  - curl -sfL https://get.k3s.io | sh -
+EOF
+}

--- a/terraform/proxmox/proxmox-001/k3s-002/output.tf
+++ b/terraform/proxmox/proxmox-001/k3s-002/output.tf
@@ -1,0 +1,19 @@
+output "id" {
+  description = "The resource ID returned by the provider"
+  value       = module.instance.id
+}
+
+output "vmid" {
+  description = "The VMID assigned to the virtual machine by Proxmox"
+  value       = module.instance.vmid
+}
+
+output "name" {
+  description = "The name of the virtual machine"
+  value       = module.instance.name
+}
+
+output "node" {
+  description = "The Proxmox node on which the VM was created"
+  value       = module.instance.node
+}


### PR DESCRIPTION
This PR adds cloud-init support to the Proxmox VM module and provisions a new k3s-002 instance. 

Key changes:
- Updated 'proxmox-vm' module to support user_data and SSH authentication.
- Added 'cloud-init' and 'curl' to the base template via Ansible.
- Provisioned 'k3s-002' with a cloud-init script to install k3s.