### PR TITLE
Fix Packer space issue and bump Debian to 13.4.0

### DIFF
--- a/packer/debian-proxmox.pkr.hcl
+++ b/packer/debian-proxmox.pkr.hcl
@@ -1,7 +1,7 @@
 locals {
-  debian_version = "12.13.0"
-  debian_iso_checksum = "2b880ffabe36dbe04a662a3125e5ecae4db69d0acce257dd74615bbf165ad76e"
-  vm_id = 201
+  debian_version = "13.4.0"
+  debian_iso_checksum = "0b813535dd76f2ea96eff908c65e8521512c92a0631fd41c95756ffd7d4896dc"
+  vm_id = 202
 }
 
 source "proxmox-iso" "debian" {
@@ -65,7 +65,7 @@ build {
   }
 
   provisioner "ansible-local" {
-    command = "source /tmp/ansible-venv/bin/activate && ANSIBLE_FORCE_COLOR=1 PYTHONBUFFERED=1 ansible-playbook"
+    command = "source /opt/ansible-venv/bin/activate && ANSIBLE_FORCE_COLOR=1 PYTHONBUFFERED=1 ansible-playbook"
     extra_arguments = [
       "-e", "ansible_python_interpreter=/usr/bin/python3",
       "-t", "operators"

--- a/packer/scripts/ansible.sh
+++ b/packer/scripts/ansible.sh
@@ -13,6 +13,8 @@ apt-get install -yq \
   wget \
   ca-certificates
 
-python3 -m venv /tmp/ansible-venv
-source /tmp/ansible-venv/bin/activate
-pip3 install -qUr /tmp/requirements.txt --no-cache-dir
+python3 -m venv /opt/ansible-venv
+/opt/ansible-venv/bin/pip install -qUr /tmp/requirements.txt --no-cache-dir
+
+
+

--- a/packer/scripts/cleanup.sh
+++ b/packer/scripts/cleanup.sh
@@ -11,6 +11,10 @@ rm -rf /dev/.udev /var/lib/dhcp3/* /var/lib/dhcp/*
 rm -rf *.iso
 rm -rf /var/tmp/* /tmp/*
 rm -rf /var/lib/cloud/instances/*
+rm -rf /opt/ansible-venv
+
+
+
 rm -f /var/lib/cloud/instance
 
 for user in root; do rm -rf /home/$user/{.viminfo,.bash_history,.ssh} ; done


### PR DESCRIPTION
This pull request bumps the Debian image version to 13.4.0 and fixes a Packer build failure.

It moves the Ansible virtualenv creation and package installation from `/tmp` to `/opt/ansible-venv` to avoid running out of space on the RAM-backed `tmpfs` filesystem that typically mounts on `/tmp` during VM provisioning.