### PR TITLE
fix(argocd): path starts with helm

### DIFF
--- a/helm/argocd/bootstrap/root-app.yaml
+++ b/helm/argocd/bootstrap/root-app.yaml
@@ -9,7 +9,7 @@ spec:
   source:
     repoURL: 'https://github.com/du3ly/homelab.git'
     targetRevision: main
-    path: argocd/applications
+    path: helm/argocd/applications
     directory:
       recurse: true
   destination:


### PR DESCRIPTION
Fix this error in ArgoCD:

> Failed to load target state: failed to generate manifest for source 1 of 1: rpc error: code = Unknown desc = argocd/applications: app path does not exist
