### PR TITLE
fix(argocd): whitelist argoproj

### DIFF
--- a/helm/argocd/app-projects/system.yaml
+++ b/helm/argocd/app-projects/system.yaml
@@ -10,6 +10,7 @@ spec:
   description: System-level ArgoCD management
   sourceRepos:
     - 'https://github.com/du3ly/homelab.git'
+    - 'https://argoproj.github.io/argo-helm'
   destinations:
     - server: 'https://kubernetes.default.svc'
       namespace: argocd


### PR DESCRIPTION
Fix in ArgoCD "argocd" Application

> application repo https://argoproj.github.io/argo-helm is not permitted in project 'system'