### PR TITLE
fix(argocd): redis needs to create serviceaccount

### DIFF
--- a/helm/argocd/applications/argocd-self-manage.yaml
+++ b/helm/argocd/applications/argocd-self-manage.yaml
@@ -17,6 +17,9 @@ spec:
         server:
           service:
             type: LoadBalancer
+        redis:
+          serviceAccount:
+            create: true
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: argocd


### PR DESCRIPTION
Fix:

> secret-init
 Checking for initial Redis password in secret argocd/argocd-redis at key auth. 
secret-init
 {"level":"fatal","msg":"secrets is forbidden: User \"system:serviceaccount:argocd:default\" cannot create resource \"secrets\" in API group \"\" in the namespace \"argocd
\"","time":"2026-05-31T04:52:39Z"}