### PR TITLE
chore(argocd): tune resources and disable unused components for lower memory footprint

### DIFF
--- a/helm/argocd/applications/argocd-self-manage.yaml
+++ b/helm/argocd/applications/argocd-self-manage.yaml
@@ -14,15 +14,79 @@ spec:
     targetRevision: '7.8.0'
     helm:
       values: |
+        # Disable unused components to save memory and reduce pods
+        dex:
+          enabled: false
+        notifications:
+          enabled: false
+        applicationSet:
+          enabled: false
+
+        # Configure resource limits and requests for remaining components
+        controller:
+          env:
+            - name: GOGC
+              value: "50"
+            - name: GOMEMLIMIT
+              value: "250Mi"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 150Mi
+            limits:
+              cpu: 500m
+              memory: 300Mi
+
+        repoServer:
+          env:
+            - name: GOGC
+              value: "50"
+            - name: GOMEMLIMIT
+              value: "100Mi"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 500m
+              memory: 200Mi
+
         server:
           service:
             type: NodePort
             nodePortHttps: 30443
+          env:
+            - name: GOGC
+              value: "50"
+            - name: GOMEMLIMIT
+              value: "80Mi"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+
         redis:
           serviceAccount:
             create: true
           secretInit:
             enabled: false
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+
+        # Tune command-line parameters for lower memory concurrency
+        configs:
+          params:
+            controller.status.processors: "5"
+            controller.operation.processors: "3"
+            reposerver.parallelism.limit: "2"
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: argocd


### PR DESCRIPTION
This PR tunes ArgoCD components to optimize memory usage in a resource-constrained environment (e.g. homelab):

1. **Disables Unused Controllers**:
   * Dex ()
   * Notifications ()
   * ApplicationSet ()
2. **Restricts Concurrency**:
   * Lowers controller status processors to 5 (from 20).
   * Lowers controller operation processors to 3 (from 10).
   * Limits reposerver parallelism to 2 (from unlimited).
3. **Optimizes Go GC**:
   * Sets  to trigger garbage collection more frequently.
   * Sets  for controller, reposerver, and server.
4. **Applies Conservative Resource Limits**:
   * Defines explicit memory/CPU requests and limits for the active pods.