### PR TITLE
fix(argocd): correct GOMEMLIMIT suffixes from Mi to MiB

### DIFF
--- a/helm/argocd/applications/argocd-self-manage.yaml
+++ b/helm/argocd/applications/argocd-self-manage.yaml
@@ -28,7 +28,7 @@ spec:
             - name: GOGC
               value: "50"
             - name: GOMEMLIMIT
-              value: "250Mi"
+              value: "250MiB"
           resources:
             requests:
               cpu: 50m
@@ -42,7 +42,7 @@ spec:
             - name: GOGC
               value: "50"
             - name: GOMEMLIMIT
-              value: "100Mi"
+              value: "100MiB"
           resources:
             requests:
               cpu: 50m
@@ -59,7 +59,7 @@ spec:
             - name: GOGC
               value: "50"
             - name: GOMEMLIMIT
-              value: "80Mi"
+              value: "80MiB"
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
This PR corrects the `GOMEMLIMIT` environment variables for ArgoCD components by changing the units suffix from standard Kubernetes `Mi` to Go-style `MiB`. 

This fixes the startup crash (`fatal error: malformed GOMEMLIMIT; see go doc runtime/debug.SetMemoryLimit`) that occurs when Go parses non-IEC unit suffixes.
