### PR TITLE
fix(argocd): correct redisSecretInit key to disable password initialization job

### DIFF
--- a/helm/argocd/applications/argocd-self-manage.yaml
+++ b/helm/argocd/applications/argocd-self-manage.yaml
@@ -71,8 +71,6 @@ spec:
         redis:
           serviceAccount:
             create: true
-          secretInit:
-            enabled: false
           resources:
             requests:
               cpu: 10m
@@ -80,6 +78,9 @@ spec:
             limits:
               cpu: 100m
               memory: 64Mi
+
+        redisSecretInit:
+          enabled: false
 
         # Tune command-line parameters for lower memory concurrency
         configs:


### PR DESCRIPTION
This PR corrects the Helm values configuration for disabling the Redis secret initialization Job.

### Issue:
The config was nested under `redis.secretInit`, which is not recognized by the `argo-cd` Helm chart. As a result, the Helm chart's default setting (`redisSecretInit.enabled: true`) remained active, scheduling the `argocd-redis-secret-init` job on every sync, causing a loop.

### Fix:
Disables the job properly using the correct top-level key:
```yaml
redisSecretInit:
  enabled: false
```
