### PR TITLE
chore(argocd): bump helm chart version to 9.5.17

### DIFF
--- a/helm/argocd/applications/argocd-self-manage.yaml
+++ b/helm/argocd/applications/argocd-self-manage.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     repoURL: 'https://argoproj.github.io/argo-helm'
     chart: argo-cd
-    targetRevision: '7.8.0'
+    targetRevision: '9.5.17'
     helm:
       values: |
         # Disable unused components to save memory and reduce pods


### PR DESCRIPTION
This PR updates the ArgoCD Helm chart from version `7.8.0` to the latest version `9.5.17` in the self-managing application config.

This upgrades the underlying ArgoCD deployment to ArgoCD v3.0, aligning it with the latest upstream features, performance enhancements, and bug fixes.
